### PR TITLE
Hip

### DIFF
--- a/data/beam/uBooNE_Booster_fhc.txt
+++ b/data/beam/uBooNE_Booster_fhc.txt
@@ -1,0 +1,11 @@
+beam_type = 2
+beam_folder = /home/lar/cthorpe/NuWro_Geom/nuwro/beams/booster_fhc/ 
+beam_file_first = 0
+beam_file_limit = 1
+
+
+#units of position values in flux file
+beam_length_units=cm
+
+#set to -1 to use default ND280 setting
+beam_pot_per_file = 5e9

--- a/data/beam/uBooNE_Numi_fhc.txt
+++ b/data/beam/uBooNE_Numi_fhc.txt
@@ -1,0 +1,14 @@
+beam_type = 2
+beam_folder = /home/lar/cthorpe/NuWro_Geom/nuwro/beams/numi_fhc/ 
+beam_file_first = 0
+beam_file_limit = 1
+
+#units of position values in flux file
+beam_length_units=cm
+
+
+#set to -1 to use default ND280 setting
+beam_pot_per_file = 1e9
+
+
+

--- a/data/beam/uBooNE_Numi_rhc.txt
+++ b/data/beam/uBooNE_Numi_rhc.txt
@@ -1,0 +1,11 @@
+beam_type = 2
+beam_folder = /home/lar/cthorpe/NuWro_Geom/nuwro/beams/numi_rhc/ 
+beam_file_first = 0
+beam_file_limit = 1
+
+#units of position values in flux file
+beam_length_units=cm
+
+
+#set to -1 to use default ND280 setting
+beam_pot_per_file = 9e8

--- a/data/beam/uBooNE_test.txt
+++ b/data/beam/uBooNE_test.txt
@@ -1,0 +1,4 @@
+beam_type = 2
+beam_folder = /home/lar/cthorpe/NuWro_Hyp_Geom/nuwro/beams/tests/ 
+beam_file_first = 0
+beam_file_limit = 1

--- a/data/target/MicroBooNE.txt
+++ b/data/target/MicroBooNE.txt
@@ -1,0 +1,11 @@
+#MicroBooNE geometry
+target_type=2
+geo_file=target/MicroBooNEGeometry.root
+geo_name=MicroBooNEGeometry
+geo_o = 128.175 0 518.5
+geo_d = 170 170 800 // half dimension of the box: dx dy dx
+
+
+geom_length_units=cm
+
+nucleus_target=2

--- a/data/target/ND280.txt
+++ b/data/target/ND280.txt
@@ -6,3 +6,7 @@ geo_o = 0 0 0 // coordinates of the center of the box: ox oy oz
 #geo_d = 1200 1200 3200 // half dimension of the box: dx dy dx
 geo_d = 1500 1500 3200 // half dimension of the box: dx dy dx
 nucleus_target=2
+
+
+geom_length_units=mm
+

--- a/data/target/ND280_975.txt
+++ b/data/target/ND280_975.txt
@@ -5,3 +5,10 @@ geo_name=ND280Geometry_v9r7p5
 geo_o = 0 0 0 // coordinates of the center of the box: ox oy oz
 geo_d = 2000 2000 5000 // half dimension of the box: dx dy dx
 nucleus_target=2
+
+#converts density used in geometry file into g/cm3
+geom_density_convert=6.24151e+18
+
+
+geom_length_units=mm
+

--- a/src/Interaction.h
+++ b/src/Interaction.h
@@ -752,7 +752,7 @@ class Interaction
                                               //!< Returns the nucleon process name.
     //added C Thorpe Dec 2018
     //calculates nucleon/hyperon cross section
-    void get_hyp_xsec(double Ek, double &nY, double &pY, particle N, particle Y, double sigma[], int &hyp_state);
+    void get_hyp_xsec(double &nY, double &pY, particle N, particle Y, double sigma[], int &hyp_state);
     //scatters hyperons, particles p1 and p2 into p[]
     bool hyperon_scattering(int hyp_state, particle& p1, particle& p2, int &n, particle p[],
                            double sigma[], double sigma_p, double sigma_n);

--- a/src/beamRF.h
+++ b/src/beamRF.h
@@ -9,6 +9,8 @@
 #include <vector>
 #include "geomy.h"
 
+double beam_length_scaling=1;	
+
 int nu_pdg_from_mode(int mode)
 {
 //~ #define MODE_NUMU_PI      11  /* numu from pi+  */
@@ -49,9 +51,17 @@ particle nu_from_event(ND5Event e)
 		int pdg=nu_pdg_from_mode(e.mode);
 		particle p( pdg, 0.0 );
 		double E=e.Enu*1000; // from GeV to MeV
-        	p.r.x = e.xnu*10;    // from cm (beam) to mm (geometry)
-        	p.r.y = e.ynu*10;    // from cm (beam) to mm (geometry)  
-        	p.r.z = 0;
+    
+	
+
+	//length scaling compares beam and geo units, sets beam units to match those in geo	
+	p.r.x = e.xnu*beam_length_scaling;
+	p.r.y = e.ynu*beam_length_scaling;
+
+	//read z component of neutrino position from file (in case beam window is not x-y plane)
+	//if not specified by flux file this should default to 0
+	p.r.z = e.znu*beam_length_scaling;
+
      		p.r.t = 0;
         	p.t=E;
         	p.x=e.nnu[0]*E;
@@ -95,7 +105,7 @@ class BeamRF : public beam
 {
 	ND5Event *events[100000];
     double P_region;
-	int N;
+	int N=0;
 	double * acum;
 	double * acum2;
 	int curevent;
@@ -103,15 +113,38 @@ class BeamRF : public beam
 	int first;
 	int limit;
 	double minx,miny,maxx,maxy;
+	double POT=0;
+	int nnu=0; //total num of events	
+	double POT_per_file=0;
+
+
+
 	
 public:
 	
 	BeamRF(params &p,geomy *detector=NULL):
 		folder(p.beam_folder),
 		first(p.beam_file_first),
-		limit(p.beam_file_limit)
+		limit(p.beam_file_limit),
+		POT_per_file(p.beam_pot_per_file)
 	{ 
         P_region=1;
+	
+	//set length units, fix geometry units and set beam length scale accordningly
+	//ND280 uses cm for beam and mm for geo
+	
+	if(p.beam_length_units == p.geom_length_units) beam_length_scaling = 1; //if beam and geo units are same, no scaling needed
+	else if(p.beam_length_units == "mm" && p.geom_length_units == "cm") beam_length_scaling = 0.1;		
+	else if(p.beam_length_units == "cm" && p.geom_length_units == "mm") beam_length_scaling = 10;
+	else if(p.beam_length_units == "m" && p.geom_length_units == "cm") beam_length_scaling = 10;
+	else if(p.beam_length_units == "m" && p.geom_length_units == "mm") beam_length_scaling = 100;
+	else if(p.beam_length_units == "cm" && p.geom_length_units == "m") beam_length_scaling = 0.1;
+	else if(p.beam_length_units == "mm" && p.geom_length_units == "m") beam_length_scaling = 0.01;
+	else
+	std::cout << "Unrecognised length units: " << p.beam_length_units << " " << p.geom_length_units << std::endl
+	<< "Use either mm, cm or m" << std::endl;
+
+
 		read_events(detector);
 		cout<<endl;
 		acum=new double[N];
@@ -119,19 +152,33 @@ public:
 		double prev=0;
 		for(int i=0;i<N;i++)
 			acum[i]=prev+=events[i/100000][i%100000].norm;
-		prev=0;
+	
+		
+		
+			prev=0;
 		for(int i=0;i<N;i++)
 		{	
 			ND5Event& ev=events[i/100000][i%100000];
 			acum2[i]=prev+=ev.norm*ev.Enu;
 		}
+			
+		//total POT used is the number of pot per file
+		//times number of files
+
+		//assumes each file has equal POT - might want to consider 
+		//storing the POT info in the root flux files themselves in future
+	
+		POT = limit*POT_per_file;
 		
 		cout<<" nu/POT="<<nu_per_POT()<<endl;
 		cout<<" POT/nu="<<1/nu_per_POT()<<endl;
 		cout<<" nfiles="<<limit<<endl;
 
-		double surf=(maxx-minx)*(maxy-miny);
-		cout<<" Beam Surface="<<maxx-minx<<" cm x "<<maxy-miny<<" cm = "<<surf<<" cm2"<<endl;
+	//this asssumed flux is produced in x-y plane - not always true
+	//replace with more suitable calculation later
+
+	//double surf=(maxx-minx)*(maxy-miny);
+	//cout<<" Beam Surface="<<maxx-minx<<" cm x "<<maxy-miny<<" cm = "<<surf<<" cm2"<<endl;
 	}
 	
 	~BeamRF()
@@ -153,7 +200,7 @@ public:
 			first=0;
 		if(limit>n || limit==0) // 0 means no limit
 			limit=n;
-		for(int i=0,j=0;i<limit;j++,++i,i%=n)
+		for(int j=0; j < limit; j++)
 		{   
 			RootFReader<ND5Event> reader( names[j], "h3002");
 			for(int k=0;k<reader.Count();k++)
@@ -183,12 +230,18 @@ public:
         cout<<total<<" events read from "<<limit<<" files.\r"<<flush;
         cout<<endl<<total-unsaved<<" neutrinos can hit the target (will be used).\r"<<endl;
         cout<<endl<<int(P_region*1e6)/1e4<<"% POTS will be used.\r"<<endl;
+	nnu = total-unsaved;
 	}
 	
 	
 ////////////////////////////////////////////////////////////////////////
 	void store( const ND5Event& e)
 	{ 		
+
+		//C Thorpe: This does not appear to affect the POT counting calculation
+		//but the assumtion made here that the flux window is the x-y plane
+		//is no longer correct - this needs updating
+
 		if(N%100000==0) 
 		{
 //		   cerr<< "File:"<<_nextFile<<" "<< N<<" beam events read...\r"<<flush;
@@ -214,7 +267,18 @@ public:
 	
 	double nu_per_POT()
 	{
-			return (acum[N-1]/limit)/1e21;//*P_region;
+/*
+	std::cout << std::endl;
+	std::cout << "total : " << nnu << std::endl;
+std::cout << "POT : " << POT << std::endl;
+	std::cout << std::endl;
+*/
+
+	//if POT per file has been specified
+	if(POT_per_file != -1) return nnu/POT;		
+	
+	//otherwise assume ND280 setup
+	else return (acum[N-1]/limit)/1e21;//*P_region;
 	}
 	
 

--- a/src/ff.cc
+++ b/src/ff.cc
@@ -144,9 +144,11 @@ double zexp_FA(const double q2, const double ma); // Z-expansion Model
 /// Calculate F1,F2
 pair<double, double> FF::f12(int kind) {
 
+ 
   double Ge = 0, Gm = 0, f1 = 0, f2 = 0, F1s = 0, F2s = 0;
   const double tau = Q2 / (4 * M2);
 
+ 
   //C Thorpe added Dec 2018
   //needed by hyperon production channels
   double f1p,f1n,f2p,f2n;
@@ -205,6 +207,7 @@ pair<double, double> FF::f12(int kind) {
   f1 = (Ge + tau * Gm) / (1 + tau);
   f2 = (Gm - Ge) / (1 + tau);
 
+ 
   if ((kind == 1 or kind == 2) and
       strangeEM)  // strangeness in F1, F2 (only for kind!=0 i.e. nc)
     switch (strangeEM) {
@@ -315,6 +318,7 @@ FF bba03_FF(const double q2) {
 ///////////////////////////////////////////////////////////////
 FF bbba05_FForig(const double q2) {
   const double tau = -q2 / (4 * M2);
+
 
   FF ff;
   ff.Q2 = -q2;
@@ -788,15 +792,19 @@ pair<double, double> fap(double q2, int kind) {
   double hyp_mass;
   double kmass = PDG::mass_K;
 
+ 
   double Ga, Fpa, Gas, Fpas;
   double Fp = 0, Fa = 0;
 
   switch (kind) {
     case 0:  // cc
+
       //Fa = Axialfromq2(q2, MA_cc); 
       Fa = Axialfromq2(q2, rew.qel_cc_axial_mass.val); 
+
       Fa *= axialcorr(axialFFset, q2);
       Fp = 2 * MM * Fa / (piMass2 - q2);
+
       break;
     case 1:  // nc proton
       //Fa = 0.5 * Axialfromq2(q2, MA_nc); 
@@ -825,26 +833,35 @@ pair<double, double> fap(double q2, int kind) {
       // Fp=2.0*M2*Fa/(piMass2 - q2) ;
       break;
 
+
     //C Thorpe added Dec 2018
     //hyperon production channels
+
 
     //Lambda zero;
     case 12:
       // need to add x=F/(F+D) value to constants file 
       // x = 0.36543014996
       //Fa = Axialfromq2(q2, MA_hyp); 
+
       Fa = Axialfromq2(q2,MA_hyp);
+     
       Fa *= (-1)*(1+2*Axial_x)/sqrt(6);
+
+      
       //SU(3) symmetry breaking
       if(sym_break == true)
       {
-        Fa *= 1.051;
+        Fa *= 1.072;
       }
       hyp_mass = PDG::mass_Lambda;
 
       //Fp = Fa*(M12+hyp_mass)*(M12+hyp_mass)/(2*(kmass*kmass-q2));
       Fp = Fa*(M12+hyp_mass)*(M12+hyp_mass)/(2*(kmass*kmass-q2));
       break;
+
+
+
 
     //Sigma zero
     case 13:
@@ -861,6 +878,9 @@ pair<double, double> fap(double q2, int kind) {
       hyp_mass = PDG::mass_Sigma;
       Fp = Fa*(M12+hyp_mass)*(M12+hyp_mass)/(2*(kmass*kmass-q2));
       break;
+
+
+
 
     //Sigma minus
     case 14:
@@ -947,8 +967,8 @@ pair<double,double>g2(double q2,int kind){
   double Rg2 = (-1)*Rg20/(pow(1-q2/(MA_hyp*MA_hyp),2));
   double Ig2 = (-1)*Ig20/(pow(1-q2/(MA_hyp*MA_hyp),2));
 
-  switch(kind)
-  {
+  switch(kind){
+
   //Lambda zero production
   case 12:
     Rg2 *= (-1)*(1+2*Axial_x)/pow(6,0.5);
@@ -967,13 +987,15 @@ pair<double,double>g2(double q2,int kind){
     Ig2 *= (1-2*Axial_x);
     break;
   
-  //for ds=0 quasielastic do not include SCC for the time being
+    //for ds=0 quasielastic do not include SCC for the time being
   default:
-    Rg2 =0;
-    Ig2 =0;
-    break;
-  }
+  Rg2 =0;
+  Ig2 =0;
+  break;
 
+
+
+  }
   return pair<double,double>(Rg2,Ig2);
 }
 

--- a/src/geomy.h
+++ b/src/geomy.h
@@ -23,6 +23,7 @@
 #include "vec.h"			//
 #include "dirs.h"
 
+
 struct material
 {
 	double A, Z, N, w_density;
@@ -53,6 +54,11 @@ class geomy
 	double npots;
 	double nuc[2];
 
+
+	double length_scale=1;
+	double density_convert=1;
+
+
 	TGeometry* geo;
 	TGeoVolume* top;
 	TGeoShape* sha1;
@@ -63,12 +69,31 @@ class geomy
 	TGeoElement* ele1;
 
 
-
+//C Thorpe: reads in length units from params file, used in density calculations
 public:
-	geomy(std::string _filename, std::string _geoname, std::string volume="", vec _d = vec(0,0,0), vec _o = vec(0,0,0) )
-	{		pots=npots=0;
+	geomy(std::string _filename, std::string _geoname,std::string geom_length_units, double geom_density_convert, std::string volume="", vec _d = vec(0,0,0), vec _o = vec(0,0,0) )
+	{		
+
+	//C Thorpe: Factor to convert density to g/cm3 - required value has been added to ND280 geom.txt file
+	density_convert=geom_density_convert;
+		
+	//set length scaling based on units provided
+	if(geom_length_units == "mm") length_scale = 0.1;
+	else if(geom_length_units == "cm") length_scale = 1;
+	else if(geom_length_units == "m") length_scale = 10;
+	else
+	std::cout << "Unrecognised geometry length units: " << geom_length_units  << std::endl<< "Use either mm, cm or m" << std::endl;
+
+		
+
+
+		pots=npots=0;
+
+
+	  	  max_length=0;
+	  	  max_density=0;
 			dens=ndens=0;
-			nuc[0]=nuc[1];
+			nuc[0]=nuc[1]=0;
 		//		mtrand.SetSeed(0);  // If seed is 0 (default value) a TUUID is generated and used to fill/*
 								// the first 8 integers of the seed array.
 								// In this case the seed is guaranteed to be unique in space and time.
@@ -133,18 +158,19 @@ public:
 	{
 		node1 = gGeoManager->FindNode(r.x, r.y, r.z);		//	TGeoNode* node1;
 		mat1 = node1->GetMedium()->GetMaterial();			//	TGeoMaterial* mat1;
-		//if(mat1->GetZ() > 50) mat1->Print();
 
-  	   //std::cout << "Mixture density: " << mat1->GetDensity() << "\n";
 		material tam;
 		if( mat1->IsMixture() ) 
 		{
 			mix1 = (TGeoMixture*)mat1;			//	TGeoMixture* mix1;
-			int n = mix1->GetNelements();			
+				
+			int n = mix1->GetNelements();	
 	        double *w=mix1->GetWmixt();
 	        double s=0;
+
 	        for(int i=0;i<n;i++)
 	            s+=w[i];
+	       
 	        s*=frandom();
 			int c = 0;
 			double a=0;
@@ -152,22 +178,37 @@ public:
 			{
 				++c;
 			}
+
+			  	
+			for(int i=0;i<n;i++){
+			  //  std::cout << mix1->GetAmixt()[i] << "   " << mix1->GetZmixt()[i] << "   " << w[i] << std::endl;
+			}
+			
+
 			tam.A = mix1->GetAmixt()[c];
 			tam.Z = mix1->GetZmixt()[c];
 			tam.N = d_round(tam.A) - tam.Z;
 		}
 		else	//if(ele1 == NULL)
 		{
+		  //  std::cout << "Not mixture" << std::endl;
 			tam.A = mat1->GetA();
 			tam.Z = mat1->GetZ();
 			tam.N = d_round(tam.A) - tam.Z;
 		}
-		double CLHEP_g_cm3=6.24151e+18;
-		tam.w_density = mat1->GetDensity()/CLHEP_g_cm3;
 		
+
+
+		//	double CLHEP_g_cm3=6.24151e+18;
+			
+		//conversion factor to get density in g/cm3	
+		//for ND280 density_convert = 6.24151e+18;
+		tam.w_density = mat1->GetDensity()/density_convert;
+
 		dens+=tam.w_density;
 		ndens++;
 		max_density = max(max_density,tam.w_density);
+//		std::cout << nuc[0] << std::endl;
 		nuc[0]+=tam.N*tam.w_density/(tam.N+tam.Z);
 		nuc[1]+=tam.Z*tam.w_density/(tam.N+tam.Z);
 		tam.r = r;
@@ -220,23 +261,34 @@ public:
 		double ta=max(x-dx,max(y-dy,z-dz));
 		double tb=min(x+dx,min(y+dy,z+dz));
 		if(tb>ta)
-		 {  double len=dir.length()*(tb-ta)*mm/cm; // from mm to cm
-
+		 { 
+			//C Thorpe: Check geom units, convert to cm
+			 
+			double len=dir.length()*(tb-ta)*length_scale; //length scale takes geom length units and converts to cm
+	
 		    if(len>frandom()*max_length)
 		      {
 			    if(len>max_length) 
 		            max_length=len;
 			    tam = getpoint(start+ (ta+frandom()*(tb-ta))*dir);
+			    
 		      }
-		  }
+		 }
 		double mol=6.02214129e23 ;
+
 		/* density is in g/cm3 
 		*  length is in cm
 		*  mol = number of nucleons per gram
 		*  pots is in nucleons/cm2
 		*/ 
+		//CT: this density is wrong - off by many OM
+		// max_length is in cm, tam.w_density is in g/cm3
+		
 		pots+=tam.w_density*max_length*mol;
 		npots++;  
+		
+
+		//	std::cout << npots << std::endl;
 		//~ cout<<tam.w_density/CLHEP_g_cm3<<'\t';
 		//~ cout<<tam.A<<'\t';
 		//~ cout<<tam.Z<<'\t';
@@ -269,7 +321,10 @@ public:
 	
 	double vol_mass()
 	{
-		return 8*dxyz.x*dxyz.y*dxyz.z*mm3*density(); 
+	 	//C Thorpe: Lengths should be in cm and density in g/cm3 for all configurations 
+	 
+	return 8*dxyz.x*dxyz.y*dxyz.z*density()*length_scale*length_scale*length_scale*cm3; 
+
 	}
 
 	double frac_proton()

--- a/src/hyperon_cascade.cc
+++ b/src/hyperon_cascade.cc
@@ -58,14 +58,7 @@ void hyperon_exp_xsec(double E, double Plab, double sigma[] , int hyp_state){
   if(Plab > 2.1){x = 2.1;}
   else {x=Plab;}
 
-
-
-
-  //R = ratio of CMS momenta 
-
-  //average of nucleon masses
-  // double M_N = (PDG::mass_proton + PDG::mass_neutron)/2;
-
+ 
   double M_N1; //initial nucleon mass
   double M_N2; //final nucleon mass
   double M_L = PDG::mass_Lambda; //lambda mass
@@ -75,15 +68,9 @@ void hyperon_exp_xsec(double E, double Plab, double sigma[] , int hyp_state){
   double R;
   
 
-
+  //Singh and Vicente Vacas fits
   double sigma_1 = (39.66 - 100.45*x + 92.44*x*x - 21.4*x*x*x)/(Plab)*millibarn;
-
-  //in Singh paper this formula includes a phase space ratio, check this
-  //is correctly propagated through the rest of the formulae   
- 
-  //maybe add factor of R in here then check formula is correct for other
-  //reactions
-double sigma_2 =  (31.1 - 30.94*x + 8.16*x*x)*millibarn;
+  double sigma_2 =  (31.1 - 30.94*x + 8.16*x*x)*millibarn;
   double sigma_3 = (11.77/Plab + 19.07)*millibarn;
   double sigma_4 =  (22.4/Plab - 1.08)*millibarn;
 
@@ -132,7 +119,6 @@ double sigma_2 =  (31.1 - 30.94*x + 8.16*x*x)*millibarn;
 
       	sigma[1] = 2*sigma_2*R;
 
-	//	std::cout << "sigma1: " << sigma[1] << std::endl;
  
       //////////////////////////////////
       // LAMBDA P -> SIGMA0 P
@@ -146,13 +132,10 @@ double sigma_2 =  (31.1 - 30.94*x + 8.16*x*x)*millibarn;
 	M_N2 = PDG::mass_proton;
 	M_S = PDG::mass_Sigma;
 
-	//	E = cms_energy(Plab*GeV,M_N1,M_L);
       
 	R = phase_space(E,M_S,M_N2,M_L,M_N1);
 
 	  sigma[2] = sigma_2*R;
-
-	  //	std::cout << "sigma2: " << sigma[2] << std::endl;
 
       }
       else {sigma[2] = 0;}
@@ -259,9 +242,8 @@ E = cms_energy(Plab*GeV,PDG::mass_neutron,PDG::mass_Sigma);
     //SIGMA0 N -> LAMBDA N
     ////////////////////////////////
 
-    //TODO check this is correct
     sigma[4] = sigma[1];
-    //std::cout << sigma[4] << std::endl;
+    
     ///////////////////////////////////////
     // SIGMA0 N -> SIGMA- P
     /////////////////////////////////////
@@ -456,15 +438,11 @@ void hyperon_state(int hyp_state,double sigma[],int &ij, particle p[]){
     //final state is lambda p
     else {
 
-      // std::cout << "Lambda proton -> Lambda Proton" << std::endl;
 
       ij=1;
 
       p[0].set_pdg_and_mass(PDG::pdg_Lambda,PDG::mass_Lambda);
       p[1].set_pdg_and_mass(PDG::pdg_proton,PDG::mass_proton);
-
-      //    std::cout << "Final state lambda proton" << std::endl;
-      //    std::cout << p[0].pdg << "  " << p[1].pdg << std::endl;
 
 
     }
@@ -528,7 +506,6 @@ else  if(hyp_state == 1){
       p[0].set_pdg_and_mass(PDG::pdg_Lambda,PDG::mass_Lambda);
       p[1].set_pdg_and_mass(PDG::pdg_proton,PDG::mass_proton);
 
-      // std::cout << "initial state sigma proton" << std::endl;
 
     }
     //final state is sigma 0 proton
@@ -657,7 +634,6 @@ else  if(hyp_state == 1){
   else 
     { 
 
-      //   std::cout << "Hyperon scatter error" << std::endl;
       ij=3; 
 
 
@@ -695,6 +671,9 @@ double phase_space(double rs, double M1a, double M2a, double M1b, double M2b){
 
     double a = cms_momentum2(rs*rs,M1a*M1a,M2a*M2a);
   double b = cms_momentum2(rs*rs,M1b*M1b,M2b*M2b);
+
+//if either process is forbidden
+if(a < 0 || b < 0) return 0;
 
   //a =  pow(rs,4) + pow(M1a,4) + pow(M2a,4) - 2*(rs*rs*M1a*M1a + rs*rs*M2a*M2a + M1a*M1a*M2a*M2a);
   //b = pow(rs,4) + pow(M1b,4) + pow(M2b,4) - 2*(rs*rs*M1b*M1b + rs*rs*M2b*M2b + M1b*M1b*M2b*M2b);

--- a/src/hyperon_interaction.cc
+++ b/src/hyperon_interaction.cc
@@ -244,6 +244,7 @@ double Singh_Model(double Q2, double E_nu, int h, vect k1, vect p1, vect k2, vec
  //assume input particles are on shell
   //set Hyperon mass
   double My = sqrt(p2*p2);
+  //std::cout << My << std::endl;
   //set nucleon mass
   double Mp = sqrt(p1*p1);
 
@@ -271,6 +272,8 @@ double Singh_Model(double Q2, double E_nu, int h, vect k1, vect p1, vect k2, vec
   double t = (k1-k2)*(k1-k2);
   double ml = sqrt(k2*k2);
   double Delta = My - Mp;
+
+
 
   //also have M = Mp+My
 

--- a/src/nucleus.cc
+++ b/src/nucleus.cc
@@ -42,6 +42,9 @@ nucleus::nucleus(params &par):
 	{
 		_kf=par.nucleus_kf;
 	}
+	//set hyperon binding energy
+	Y_Eb = par.hyp_Eb;
+
 }
 
 double nucleus::density (double r)

--- a/src/nucleus.h
+++ b/src/nucleus.h
@@ -46,6 +46,8 @@ class nucleus
 						  /// 4 - spectral function (for carbon and oxygen, else lFG); 
 						  /// 5 - deuterium (forced for H2); 
 						  /// 6 - proton in deuterium (for tests only);
+	//hyperon potential at r=0
+	double Y_Eb;
 		 
 	public:
 
@@ -78,6 +80,9 @@ class nucleus
 	bool pauli_blocking (particle & pa);     ///< true if the particle is blocked
 	bool pauli_blocking (particle p[], int n); ///< true if any of p[0]..p[n-1] is blocked (used in cascade)
 	bool pauli_blocking_old (particle &pa, double p0); ///< TRUE = PARTICLE IS BLOCKED (p0 - momentum of initial nucleon)
+
+	double hyp_BE(double r);
+
 };
 
 ////////////////////////////////////////////////////////////////////////
@@ -228,5 +233,13 @@ inline double nucleus::V(particle &p)
 	double lkf = localkf(p);
 	return (sqrt(p.mass2() + lkf*lkf) - p.mass());// + 7*MeV);// + 5*MeV;
 }
+
+inline double nucleus::hyp_BE(double r){
+
+  return Y_Eb*density(r)/density(0);
+
+
+}
+
 
 #endif

--- a/src/nuwro.cc
+++ b/src/nuwro.cc
@@ -34,6 +34,8 @@
 #include "Interaction.h"
 #include "rew/rewparams.h"
 
+
+
 extern double SPP[2][2][2][3][40];
 //extern double sppweight;
 extern "C" {
@@ -102,10 +104,11 @@ geomy* NuWro::make_detector(params &p)
 	{
 		try
 		{
+
 			if(p.geo_d.norm2()==0)
-				return new geomy(p.geo_file,p.geo_name);
+				return new geomy(p.geo_file,p.geo_name,p.geom_length_units,p.geom_density_convert);
 			else
-				return new geomy(p.geo_file,p.geo_name,p.geo_volume,p.geo_d,p.geo_o);
+				return new geomy(p.geo_file,p.geo_name,p.geom_length_units,p.geom_density_convert,p.geo_volume,p.geo_d,p.geo_o);
 		}
 		catch(...)
 		{
@@ -137,9 +140,7 @@ void NuWro::init (int argc, char **argv)
 	_progress.open(a.progress);
 	frandom_init(p.random_seed);
 
-  // load the input data
-  input.initialize( p );
-  input.load_data();
+  
 
 	if(p.beam_test_only==0 && p.kaskada_redo==0)
 		if(p.dyn_dis_nc or p.dyn_res_nc  or p.dyn_dis_cc or p.dyn_res_cc )
@@ -166,6 +167,13 @@ void NuWro::init (int argc, char **argv)
 
 
 	}
+
+
+// load the input data
+  input.initialize( p );
+  input.load_data();
+
+
 	ff_configure(p);
 	refresh_dyn(p);	
 }
@@ -376,11 +384,14 @@ void NuWro::makeevent(event* e, params &p)
 					case 5:mecevent_SuSA (p, *e, *_nucleus, true);break;
 					default:mecevent_tem (p, *e, *_nucleus, true);break;
 				}
+			
 				for(int i=0;i<e->out.size();i++)
 				{
 					e->out[i].r=e->in[1].r;
 					e->out[i].set_momentum(e->out[i].p().fromZto(e->in[0].p()));
 				}
+			
+			
 			}
 			break;
 		case 9:
@@ -523,7 +534,9 @@ void NuWro::pot_report(ostream& o)
 	double tot=0;
 	if(_detector)
 	{
+	  //CT: Something wrong with this calculation for uB
 		double pd=_detector->nucleons_per_cm2();
+
 		for(int i=0;i<_procesy.size();i++)
 		if(_procesy.avg(i)>0)
 		{	
@@ -533,16 +546,22 @@ void NuWro::pot_report(ostream& o)
 			o  <<"       POT per event = "<<1/epp<<endl;
 		}
 		double epp=tot*pd*_beam->nu_per_POT();
-			
+		
+
+	
 		o<<"Total: events per POT= "<<epp<<endl
-		 <<"       POT per event = "<<1/epp<<endl<<endl;
+		 <<"       POT per event = "<<1/epp<<endl;
 		o<<" BOX nuclons per cm2 = "<<pd<<endl;
 		o<<"Total cross section  = "<<tot<<" cm2"<<endl;
 		o<<"Reaction probability = "<<tot*pd<<endl;
 		o<<"Average BOX density  = "<<_detector->density()/g*cm3<<" g/cm3"<< endl;
-		o<<"Estimated BOX mass   = "<<_detector->vol_mass()/kg<<" kg"<<endl;	
-		o<<"Fraction of protons  = "<<_detector->frac_proton()<<endl;
 		
+		o<<"Estimated BOX mass   = "<<_detector->vol_mass()/kg<<" kg"<<endl;	
+
+		o<<"Fraction of protons  = "<<_detector->frac_proton()<<endl;
+
+	o << "Total POT: " << p.number_of_events/epp << std::endl;
+
 	}
 }
 

--- a/src/params.xml
+++ b/src/params.xml
@@ -67,6 +67,30 @@
           <param name="beam_file_limit" type="text" ctype="int" default="0">
             <description></description>
           </param>
+
+	<!-- C Thorpe: New beam pot per file parameter - if set to -1 will use old ND280 setup -->
+
+	<param name="beam_pot_per_file" type="text" ctype="double" default="-1">
+	 <description>Beam POT per file</description>
+	</param>
+	
+	<!-- Defaults are ND280 conventions -->
+
+	<param name="geom_length_units" type="text" ctype="string" default="cm">
+	<description>Length units used by geometry</description>
+	</param>
+	
+	<param name="geom_density_convert" type="text" ctype="double" default="1.0">
+	<description>Factor to convert geometry density units to g/cm3</description>
+	</param>
+
+	<param name="beam_length_units" type="text" ctype="string" default="cm">
+	<description>Length units used by beam</description>
+	</param>
+
+
+
+
           <param name="beam_weighted" type="checkbox" ctype="bool" default="0">
             <description></description>
           </param>
@@ -510,9 +534,14 @@
   <param name="pauli_blocking" type="checkbox" ctype="bool" default="1">
     <description><![CDATA[enable (1) or not (0) Pauli blocking]]></description>
   </param>
+
+
+
   <param name="mixed_order" type="checkbox" ctype="bool" default="1">
     <description><![CDATA[random order of events in uotut file]]></description>
   </param> 
+
+
 
 <!-- Cascade hyperon KE cutoff -->
 <!--

--- a/src/params.xml
+++ b/src/params.xml
@@ -67,7 +67,6 @@
           <param name="beam_file_limit" type="text" ctype="int" default="0">
             <description></description>
           </param>
-<<<<<<< HEAD
          
 
 
@@ -95,33 +94,6 @@
 
 
 	 <param name="beam_weighted" type="checkbox" ctype="bool" default="0">
-=======
-
-	<!-- C Thorpe: New beam pot per file parameter - if set to -1 will use old ND280 setup -->
-
-	<param name="beam_pot_per_file" type="text" ctype="double" default="-1">
-	 <description>Beam POT per file</description>
-	</param>
-	
-	<!-- Defaults are ND280 conventions -->
-
-	<param name="geom_length_units" type="text" ctype="string" default="cm">
-	<description>Length units used by geometry</description>
-	</param>
-	
-	<param name="geom_density_convert" type="text" ctype="double" default="1.0">
-	<description>Factor to convert geometry density units to g/cm3</description>
-	</param>
-
-	<param name="beam_length_units" type="text" ctype="string" default="cm">
-	<description>Length units used by beam</description>
-	</param>
-
-
-
-
-          <param name="beam_weighted" type="checkbox" ctype="bool" default="0">
->>>>>>> ec7c39e53a2d756f6e022605137d3b0c2ef97839
             <description></description>
           </param>
           <param name="beam_offset" type="text" ctype="vec" default="0 0 0">

--- a/src/params.xml
+++ b/src/params.xml
@@ -67,6 +67,35 @@
           <param name="beam_file_limit" type="text" ctype="int" default="0">
             <description></description>
           </param>
+<<<<<<< HEAD
+         
+
+
+   <!-- C Thorpe: New beam pot per file parameter - if set to -1 will use old ND280 setup -->
+
+        <param name="beam_pot_per_file" type="text" ctype="double" default="-1">
+         <description>Beam POT per file</description>
+        </param>
+
+        <!-- Defaults are ND280 conventions -->
+
+        <param name="geom_length_units" type="text" ctype="string" default="cm">
+        <description>Length units used by geometry</description>
+        </param>
+
+        <param name="geom_density_convert" type="text" ctype="double" default="1.0">
+        <description>Factor to convert geometry density units to g/cm3</description>
+        </param>
+
+        <param name="beam_length_units" type="text" ctype="string" default="cm">
+        <description>Length units used by beam</description>
+        </param>
+
+
+
+
+	 <param name="beam_weighted" type="checkbox" ctype="bool" default="0">
+=======
 
 	<!-- C Thorpe: New beam pot per file parameter - if set to -1 will use old ND280 setup -->
 
@@ -92,6 +121,7 @@
 
 
           <param name="beam_weighted" type="checkbox" ctype="bool" default="0">
+>>>>>>> ec7c39e53a2d756f6e022605137d3b0c2ef97839
             <description></description>
           </param>
           <param name="beam_offset" type="text" ctype="vec" default="0 0 0">
@@ -549,6 +579,12 @@
 <description>Hyperon kinetic energy cutoff</description>
 </param>
  -->
+
+<param name="hyp_Eb" type="text" ctype="double" default="30">
+<description>Hyperon binding energy at max density</description>
+</param>
+
+
 
 </params>
 

--- a/src/params_all.h
+++ b/src/params_all.h
@@ -13,6 +13,10 @@ PARAM(line,beam_content,"")\
 PARAM(string,beam_folder,"flux")\
 PARAM(int,beam_file_first,1)\
 PARAM(int,beam_file_limit,0)\
+PARAM(double,beam_pot_per_file,-1)\
+PARAM(string,geom_length_units,"cm")\
+PARAM(double,geom_density_convert,1.0)\
+PARAM(string,beam_length_units,"cm")\
 PARAM(bool,beam_weighted,0)\
 PARAM(vec,beam_offset,"0 0 0")\
 PARAM(int,beam_placement,0)\

--- a/src/params_all.h
+++ b/src/params_all.h
@@ -119,4 +119,5 @@ PARAM(int,kaskada_NN_corr,1)\
 PARAM(int,kaskada_piN_xsec,1)\
 PARAM(bool,pauli_blocking,1)\
 PARAM(bool,mixed_order,1)\
+PARAM(double,hyp_Eb,30)\
 

--- a/src/particle.cc
+++ b/src/particle.cc
@@ -18,7 +18,10 @@ decay (vect p4, particle & p1, particle & p2)
       xx = 2 * frandom () - 1;
       yy = 2 * frandom () - 1;
       zz = 2 * frandom () - 1;
-    }
+      
+      
+
+}
   while ((rr = xx * xx + yy * yy + zz * zz) > 1);
   // value of momentum of decay products in cms frame
 //  double m1m1 = p1.mass () * p1.mass ();

--- a/src/particle.h
+++ b/src/particle.h
@@ -29,7 +29,7 @@ public:
 	int endproc;     ///< id of process that destroyed the particle
 	double his_fermi;
 	bool primary;
-  
+	
 public:
 	inline particle(){travelled=x=y=z=t=_mass=pdg=mother=0;id=-1;his_fermi=0;}
 	inline particle (int code,double mass);      ///< create particle at rest 
@@ -74,6 +74,9 @@ public:
   inline bool nucleon();            ///true if nucleon
   inline bool proton();             ///true if proton
 	inline bool neutron();						///true if neutron
+
+
+
 
 	inline particle& mom()                      ///mother particle !!! ONLY for elements of the vector all !!!
 	{  return this[mother-id];
@@ -241,6 +244,8 @@ void particle::set_energy (double E)
     }
   }
 
+
+
 vec particle::p ()
   {
     return vec(x,y,z);
@@ -325,13 +330,22 @@ double particle::Ek_in_frame (vec v)
   return plab.boost (-v).t-mass();
 }
 
+
+
+
+
+
+
+
 ////////////////////////////////////////////////////////////
 ///  M2 = squared mass of decaying particle 
 ///  ma2, mb2 = squared masses of decay products
 /// result = squared momentum of decay products (in cms) if decay possible
 ///          negative number if deacy is impossible
 inline double cms_momentum2(double M2,double ma2,double mb2)
-{ if(M2<ma2+mb2) return -1; 
+//cthorpe: I think it should be this
+{ if(M2 < ma2+mb2+2*sqrt(ma2)*sqrt(mb2)) return -1; // M^2 > (m1 + m2)^2 = m1^2 + m2^2 + 2*m1*m2
+//{ if(M2<ma2+mb2) return -1; 
   double X=M2+ma2-mb2;
   return X*X/4/M2-ma2;
 }
@@ -342,5 +356,9 @@ inline double cms_momentum(double M,double ma,double mb)
   
   return sqrt(X)/(2*M);
 }
+
+
+
+
 
 #endif

--- a/src/rootf.h
+++ b/src/rootf.h
@@ -16,13 +16,13 @@ struct ND5Event
 	
 	Float_t Enu; 		/// energia
 	Float_t nnu[3]; 	/// x, y, z kierunek pedu
-	Float_t xnu, ynu; 	/// wsp. gdzie neutrino przecina plaszczyzne Z=0
+	Float_t xnu, ynu, znu; 	/// wsp. gdzie neutrino przecina plaszczyzne Z=0
 	Int_t mode;	        /// reaction mode
 //	UChar_t gipart; 	/// pdg neutrino mionowa 14
 //	Int_t idfd; 		/// sprawdzic czy jest to wartosc 5, identyfikacje detektora
 	Float_t norm; 	    /// norma neutrina
 	
-	ND5Event(  ) : Enu(0), xnu(0), ynu(0), mode(0), /*idfd(0),*/ norm(1)
+	ND5Event(  ) : Enu(0), xnu(0), ynu(0), znu(0), mode(0), /*idfd(0),*/ norm(1)
 	{
 		nnu[0] = 0;
 		nnu[1] = 0;
@@ -31,10 +31,12 @@ struct ND5Event
 
 	void CreateBranches( TTree * tree )
 	{
+		
 		tree->Branch( "Enu", &Enu, "Enu/F" );
 		tree->Branch( "nnu", &nnu, "nnu[3]/F" );
 		tree->Branch( "xnu", &xnu, "xnu/F" );
 		tree->Branch( "ynu", &ynu, "ynu/F" );
+		tree->Branch( "znu", &znu, "znu/F" );
 		tree->Branch( "mode", &mode, "mode/I" );
 //		tree->Branch( "gipart", &gipart, "gipart/I" );
 //		tree->Branch( "idfd", &idfd, "idfd/I" );
@@ -51,6 +53,7 @@ struct ND5Event
 		tree->SetBranchAddress( "nnu", &nnu );
 		tree->SetBranchAddress( "xnu", &xnu );
 		tree->SetBranchAddress( "ynu", &ynu );
+		tree->SetBranchAddress( "znu", &znu );
 		tree->SetBranchAddress( "mode", &mode );
 //		tree->SetBranchAddress( "gipart", &gipart );
 //		tree->SetBranchAddress( "idfd", &idfd );

--- a/src/scatter.cc
+++ b/src/scatter.cc
@@ -1,6 +1,8 @@
+
 #include "scatter.h"
 #include "particle.h"
 #include <TGenPhaseSpace.h>
+#include <iomanip>
 
 /// transate root TLorentzVector to vect
 static inline vect makevect (TLorentzVector * v)
@@ -117,3 +119,245 @@ int scatter_n (int n, particle p1, particle p2,
       }
     return 1;
   }
+
+//added by CThorpe
+
+//solve kinematics with hyperon BE using self consistency method:
+
+//Boost initial particles into CMS
+//Generate a scattering angle for the hyperon
+//guess an effective mass for the hyperon
+//boost back to lab
+//check if eff mass is consistent with on shell hyperon modified for binding energy
+//if not guess a new value and repeat until they match
+
+double scatter2_with_BE_SC(particle p1,particle p2, particle &p3, particle &p4, double Y_Eb){
+
+  double range = 0.01; //maximum allowed disagreement between two calculations of effective mass
+
+  //compute the 4 momentum of cms
+ vect suma = vect (p1) + vect (p2);
+  if(suma*suma<=0) return 0;
+
+  double s = suma*suma; //squared cms energy
+  double pcms2=0;
+
+
+  // std::cout << std::endl;
+  // std::cout << "Method 1" << std::endl;
+
+  particle hyp = p4;
+  particle lep = p3;
+
+  vec vcms = suma.v();
+
+  // p1.boost(-vcms);
+  // p2.boost(-vcms);
+
+  //make initial guess of hyperon effective mass as nucleon mass minus lepton mass
+  //this gaurentees this initial attempt will always succeed
+
+  hyp.set_mass(sqrt(s) - lep.mass()-3);
+
+  //perform the decay IN THE CMS using this initial guess
+
+  ::decay(vect(p1)+vect(p2), hyp, lep);
+
+      //get the direction of the 3 momentum of the hyperon in the cms
+      vec unit_vec = vec(hyp) / vec(hyp).length();
+
+      //boost to lab
+
+      hyp.boost(vcms);
+      lep.boost(vcms);
+     
+ double diff=0;
+  
+//cap at 50 iterations (usually finds eff mass in <5) 
+  for(int i=0;i<50;i++){
+    
+
+  //check is hyperon's 4 momentum consistent with BE adjustment
+ 
+  double calc_energy = hyp.t;
+  double target_energy =  sqrt(p4.mass()*p4.mass() + hyp.length()*hyp.length()) - Y_Eb;
+
+    //break the loop when the values are close enough or if step size falls below target size
+    if(calc_energy < target_energy + range/2 && calc_energy > target_energy - range/2) break; 
+
+
+    diff = calc_energy - target_energy; //difference between two energy calculations - when this is zero you have correct effective mass
+
+    //boost back to cms
+    hyp.boost(-vcms);
+    lep.boost(-vcms);
+    
+ double hyp_mass = hyp.mass();
+
+  label:
+    //get new estimate of hyperon effective mass
+
+    hyp.set_mass(hyp_mass - diff);
+
+
+    //recalculate the cms momentum
+    //if this fails then pcms2=-1
+
+    pcms2 = cms_momentum2(s,lep.mass2(),hyp.mass2());
+
+    //if unable to generate kinematics for this 
+    if(pcms2 < 0 && abs(diff) > range/2){ 
+
+diff /= 2;
+ goto label;
+
+    }
+    else if(abs(diff)<range/2){
+
+      return 0;
+    }
+ 
+  hyp.set_momentum(unit_vec * sqrt(pcms2) );
+  lep.set_momentum(-unit_vec * sqrt(pcms2) );
+
+
+  //boost back to lab
+  hyp.boost(vcms);
+      lep.boost(vcms);
+
+
+  }
+  
+
+  //having found the correct effective mass,
+  //set the outgoing particle 4 momenta and masses
+
+  double hyp_mass = p4.mass();
+
+  p3 = lep;
+  p4 = hyp;
+
+
+  double q2 = (lep.t - p1.t)*(lep.t - p1.t) - (vec(p1)-vec(lep))*(vec(p1)-vec(lep));
+
+  return q2;
+}
+
+
+//Modified cms energy trick
+
+double scatter2_with_BE(particle p1,particle p2, particle &p3, particle &p4, double Y_Eb, vec &cms_dir){
+
+  particle hyp = p4;
+  particle lep = p3;
+
+  //compute the 4 momentum of cms blob
+ vect suma = vect (p1) + vect (p2);
+  if(suma*suma<=0) return 0;
+
+  //to boost to cms
+  vec vcms = suma.v();
+
+  //generate random unit vector in true cms
+
+  double xx,yy,zz,rr;
+
+ do
+    {
+      xx = 2 * frandom () - 1;
+      yy = 2 * frandom () - 1;
+      zz = 2 * frandom () - 1;
+      
+      
+}
+ while ((rr = sqrt(xx * xx + yy * yy + zz * zz)) > 1);
+
+ vec dir(xx/rr,yy/rr,zz/rr);
+
+ vect true_cms_dir(1,dir);
+ 
+ //boost this vector to the lab frame
+ true_cms_dir.boost(vcms);
+
+  //take the total initial 4 momentum and add the hyperon BE
+  vect suma_be = suma;
+  suma_be.t += Y_Eb;
+
+  //to boost to modified cms
+  vec vcms_be = suma_be.v();
+
+//boost direction vector into modified cms
+  true_cms_dir.boost(-vcms_be);
+
+  //try to decay the CMS
+
+  double s = suma_be*suma_be; //squared cms energy
+double pp = cms_momentum2(s,p3.mass2(),p4.mass2());
+
+//forbidden by kinematics
+ if(pp <= 0 ) return 0;
+
+ lep.set_momentum( vec(true_cms_dir)/vec(true_cms_dir).length() * sqrt(pp)  );
+ hyp.set_momentum( - vec(true_cms_dir)/vec(true_cms_dir).length() * sqrt(pp)  );
+
+  lep.t = sqrt(lep.mass()*lep.mass() + pp );
+
+ hyp.t = sqrt(hyp.mass()*hyp.mass() + pp );
+
+
+//record direction of outgoing lepton in cms for use in rescale_momenta
+ cms_dir = dir;
+
+//boost back to lab
+ lep.boost(vcms_be);
+  hyp.boost(vcms_be);
+ 
+   //subtract BE off hyperon energy 
+   hyp.t -= Y_Eb;
+
+
+  //calculate the q2
+
+   double q2 = (lep.t - p1.t)*(lep.t - p1.t) - (vec(p1)-vec(lep))*(vec(p1)-vec(lep));
+
+
+     p3 = lep;
+     p4 = hyp;
+
+  return q2;
+
+
+}
+
+//given the 4 momentum of the cms object pcms
+//and a direction in the cms you want it to decay in cms_dir
+//into two particles p3 and p4.
+
+//cms_dir should be unit vector
+bool rescale_momenta(vect pcms, vec cms_dir, particle &p3, particle &p4,double Y_Eb){
+
+  pcms.t += Y_Eb;
+
+  vec vcms_be = pcms.v();
+
+  double s = pcms*pcms;
+
+  double pp = cms_momentum2(s,p3.mass2(),p4.mass2());
+
+  if(pp < 0) return false; //process not allowed by kinematics
+
+  p3.set_momentum( cms_dir * sqrt(pp) );
+  p4.set_momentum( -cms_dir * sqrt(pp) );
+
+  p3.t = sqrt(p3.mass()*p3.mass() + pp );
+
+ p4.t = sqrt(p4.mass()*p4.mass() + pp );
+
+ p3.boost(vcms_be);
+ p4.boost(vcms_be);
+
+ p4.t -= Y_Eb;
+
+  return true;
+
+}

--- a/src/scatter.h
+++ b/src/scatter.h
@@ -18,5 +18,13 @@ double scatter_2 (particle p1,  particle p2,
 bool scatterAB (particle p1, particle p2, 
 	   particle & p3, particle & p4,
 	   double A, double B, double C, double D, double E, double F, double G, double H);
+
+//added by CThorpe
+double scatter2_with_BE_SC(particle p1,particle p2, particle &p3, particle &p4, double Y_Eb);
+
+double scatter2_with_BE(particle p1,particle p2, particle &p3, particle &p4, double Y_Eb, vec &cms_dir);
+
+bool rescale_momenta(vect pcms, vec cms_dir, particle &p3, particle  &p4, double Y_Eb);
+
 #endif
 


### PR DESCRIPTION
I have updated the beam/geometry setup to improve the compatibility with other experiments:

You now specify the length units used for placing the beam window in the geometry and the units used for dimensions of volumes in the geometry. Code assumes geometry density is given in g/cm3, conversion factor can be specified in params (needed in ND280 case). The z coordinate of neutrino starting position can now be specified in case beam window is not in x-y plane.

Hyperon potential has been added:

Hyperons are subjected to potential proportional to local density of nuclear material. This affects how neutrino interaction kinematics are solved and hyperons can now be jailed by the cascade if unable to overcome this potential. 
