### PR TITLE
Avoid modifying the environment variable PATH

### DIFF
--- a/src/dirs.cc
+++ b/src/dirs.cc
@@ -41,20 +41,23 @@ void set_dirs (char* exename)
 	 { char *p=getenv("PATH");
 	   if(p)
 	   { 
-		   while(*p)
-		   {
-			   char *q=p;
-			   while(*q && *q!=':') 
-				  q++;
-			   if(*q) 
-				 *q++=0;
-			   if(ifstream((string(p)+"/"+exename).c_str()))
-				  {bin_dir=string(p)+"/";
-				   data_dir=bin_dir+"../data/";
-				   return;
-				  }
-				p=q;
-		   }
+               string duplicated_path = p;
+               size_t idx_begin = 0;
+               size_t idx_end = duplicated_path.find(':');
+               while (true) {
+                   std::string bin_path = duplicated_path.substr(idx_begin, idx_end-idx_begin);
+                   if (ifstream((bin_path+"/"+exename).c_str())) {
+                       bin_dir=bin_path+"/";
+                       data_dir=bin_dir+"../data/";
+                       return;
+                   }
+                   if (idx_end == string::npos) {
+                       break;
+                   }
+                   idx_begin = idx_end+1;
+                   idx_end = duplicated_path.find(':', idx_begin);
+               }
+
    	   } 	
 	 } 
 	 // try to use the environment variable "NUWRO"


### PR DESCRIPTION
Dear NuWro developers,

I am Tao Lin from IHEP, Beijing. I am working on the offline software for JUNO experiment. 
I found that when append the path of nuwro to $PATH, I encounter following error from nuwro:
```
sh: ldd: command not found
```

After debugging, I found the environment variable PATH is modified in dirs.cc.
So I update this part, and use the c++ std::string to search the path. 

Please review this PR. Thank you!

Tao Lin