### PR TITLE
Changes to Include QEL Hyperon Production and Generic Fluxes/Geometries

### DIFF
--- a/data/params.txt
+++ b/data/params.txt
@@ -238,8 +238,8 @@ hyp_axial_mass=1000      // Hyperon axial mass
 
 hyp_effmass=0            // Use effective masses in hyperon cross section calculation
 
-hyp_Lambda_Eb=30         // Lambda-nucleus potential strength
-hyp_Sigma_Eb=-30         // Sigma-nucleus potential strength
+hyp_Lambda_Eb=0         // Lambda-nucleus potential strength
+hyp_Sigma_Eb=0         // Sigma-nucleus potential strength
 
 ################################################################
 #

--- a/data/params.txt
+++ b/data/params.txt
@@ -70,6 +70,7 @@ dyn_coh_cc =1      // Coherent charged current
 dyn_coh_nc =0      // Coherent neutral current
 dyn_mec_cc =1      // Meson exchange charged current
 dyn_mec_nc =0      // Meson exchange neutral current
+dyn_hyp_cc =1      // Quasi elastic hyperon production
 
 dyn_e_el   =0      // Elastic electron scattering
 
@@ -221,6 +222,24 @@ mec_back_to_back_smearing = 0 //smearing of originally back-to-back correlated p
 MEC_pauli_blocking = 1 //switch on/off Pauli blocking for nucleons from MEC dynamics; default 1 (on)
 mec_pb_trials = 30 //how many times configuration satisfying Pauli blocking is searched for; default 25
 MEC_cm_direction = 0 //in CM frame prefered directions along (>0.0) or perpendicular (<0.0) wrt momentum transfer; | | cannot be larger than 1
+
+################################################################
+# Hyperon Production
+###############################################################
+
+hyp_lambda=1	         // Lambda zero baryon production
+hyp_sigma_zero=1         // Sigma zero baryon production
+hyp_sigma_minus=1        // Sigma minus baryon production
+
+hyp_g2_Re_part=0         // Real part second class current
+hyp_g2_Im_part=0         // Imaginary part second class current
+hyp_su3_sym_breaking=0   // SU(3) symmetry breaking
+hyp_axial_mass=1000      // Hyperon axial mass
+
+hyp_effmass=0            // Use effective masses in hyperon cross section calculation
+
+hyp_Lambda_Eb=30         // Lambda-nucleus potential strength
+hyp_Sigma_Eb=-30         // Sigma-nucleus potential strength
 
 ################################################################
 #

--- a/data/target/ND280.txt
+++ b/data/target/ND280.txt
@@ -8,3 +8,6 @@ geo_d = 1500 1500 3200 // half dimension of the box: dx dy dx
 nucleus_target=2
 
 geom_length_units=mm
+
+#converts density used in geometry file into g/cm3
+geom_density_convert=6.24151e+18

--- a/src/Interaction.cc
+++ b/src/Interaction.cc
@@ -226,6 +226,10 @@ void Interaction::total_cross_sections(particle &p1, nucleus &t, interaction_par
   NN_inel->set_input_point( X.Ekeff );
   double inel_ii = NN_inel->get_value( 1 );
   double inel_ij = NN_inel->get_value( 2 );
+
+
+  int ij=0;
+
   if( X.Ekeff <= 280. )                // inelastic threshold
   {inel_ii = 0.;inel_ij =0.;}
 
@@ -255,7 +259,7 @@ void Interaction::total_cross_sections(particle &p1, nucleus &t, interaction_par
     case pdg_SigmaM:
       // new method added below to house nucleon/hyperon scattering cross section
       // a new parameter was added to Interaction.h to store the pdg code of the hyperon
-      get_hyp_xsec(X.Ekeff,X.xsec_n,X.xsec_p,X.p2,p1,X.sigma,X.hyp_state);
+      get_hyp_xsec(X.xsec_n,X.xsec_p,X.p2,p1,X.sigma,X.hyp_state);
       break;
 
     default: // rest is pions!
@@ -324,7 +328,7 @@ bool Interaction::particle_scattering (particle & p1, nucleus &t, interaction_pa
     case pdg_SigmaM:
     case pdg_SigmaP:
       k1 = hyperon_;
-      return hyperon_scattering(X.hyp_state,p1,X.p2,X.n,X.p,X.sigma,X.xsec_p,X.xsec_n);
+      return hyperon_scattering(X.hyp_state,p1,X.p2,t,X.n,X.p,X.sigma,X.xsec_p,X.xsec_n);
 
     default:
       return 0;
@@ -387,28 +391,16 @@ void Interaction::get_NN_xsec( double Ek, double &resii, double &resij )
   {
     NN_xsec->set_input_point( Ek );
 
+
     resii = NN_xsec->get_value(1);
     resij = NN_xsec->get_value(2);
+
   }
 }
 
 ////////////////////////////////////////                                               
 
-// ADDED C THORPE DEC 2018                                                              
-// hyperon nucleon scatter                                                              
-
-/* Argument list:                                                                      
-Ek hyperon KE in target rest frame                                                    
-nY neutron hyperon cross sections                                                      
-pY proton hyperon cross sections                                                       
-N initial nucleon                                                                      
-Y initial hyperon                                                                      
-sigma[] array of cross sections for up to 6 possible reactions                         
-hyp_state indicates starting nucleon and hyperon                                       
-*/
-
-void Interaction::get_hyp_xsec(double &nY, double &pY,particle N,particle Y,
-			       double sigma[], int &hyp_state)
+void Interaction::get_hyp_xsec(double &nY, double &pY,particle N,particle Y,double sigma[], int &hyp_state)
 {
   switch(Y.pdg){
   case PDG::pdg_Lambda:
@@ -437,7 +429,7 @@ void Interaction::get_hyp_xsec(double &nY, double &pY,particle N,particle Y,
   v = (vect(N) + vect(Y)).v();
 
   // CMS energy
-  // required to check which final states are accessible
+  // Required to check which final states are accessible
 
   double E = sqrt((N+Y)*(N+Y));
 
@@ -530,6 +522,8 @@ bool Interaction::nucleon_scattering ( particle& p1, particle& p2, int &n, parti
   double s1  = get_NN_xsec_ij( Ek1 );
   double s2  = get_NN_xsec_ij( Ek2 );
 
+  double Ek_used = -1;
+
   if( frandom()*(s1 + s2) < s2 )
   {
     p2.x *= -1;
@@ -537,12 +531,16 @@ bool Interaction::nucleon_scattering ( particle& p1, particle& p2, int &n, parti
     p2.z *= -1;
     NN_inel->set_input_point( Ek2 );
     NN_angle->set_input_point( Ek2 );
+    Ek_used = Ek2;
   }
   else
   {
     NN_inel->set_input_point( Ek1 );
     NN_angle->set_input_point( Ek1 );
+    Ek_used = Ek1;
   }
+
+
 
   if ( frandom() > NN_inel->get_value( 1+ij ) )  // 1 is ii, 2 is ij
       return nucleon_elastic(p1, p2, n, p);
@@ -587,6 +585,7 @@ bool Interaction::nucleon_spp( particle p1, particle p2, int &n, particle p[] )
        {{f1[0],"pp."},{    1,"np+"},{ 1,"ddd"}} //pp
       };
   doit(n,cnls[canal],p);  // p[2] is pion 
+
   return scatter_n (n, p1, p2, p);
 }
 
@@ -612,6 +611,7 @@ bool Interaction::nucleon_dpp( particle p1, particle p2, int &n, particle p[] )
 
 int Interaction::nucleon_process_id()
 {
+	//std::cout << nucleon_ << " " << k2 << std::endl;
   return nucleon_+k2;
 }
 
@@ -626,72 +626,93 @@ const char* Interaction::nucleon_process_name()
     return NULL;
 }
 
-//////////////////////////////////////                                                 
-//// Added by c thorpe Jan 2019                                                        
-//// Hyperon Scattering Methods                                                        
-//// scatter hyperon either according to disribution for NN scatter                    
-//// If no NN process with same charges exists scatter isotropically in CMS frame      
-//////////////////////////////////////                                                 
+////////////////////////////////////////////////////////////////////////////////
+// Added by C Thorpe Jan 2019                                                        
+// Hyperon Scattering Methods                                                        
+// Scatter hyperon either according to disribution for NN scatter                    
+// If no NN process with same charges exists scatter isotropically in CMS frame      
+////////////////////////////////////////////////////////////////////////////////
 
-bool Interaction::hyperon_scattering(int hyp_state, particle& p1, particle& p2, int &n,
+bool Interaction::hyperon_scattering(int hyp_state, particle& p1, particle& p2,nucleus t, int &n,
                                      particle p[], double sigma[], double sigma_p, double sigma_n)
 {
-  int res;
+   int res;
 
-  // set value of hyp state, now specific for protons and neutrons
-  if(p2.pdg == PDG::pdg_neutron)
-  {
-    hyp_state += 4;
-  }
+   // Set value of hyp state, for initial state
+   if(p2.pdg == PDG::pdg_neutron)
+   {
+      hyp_state += 4;
+   }
 
-  // selects the final state for the hyperons
+  // Select final state
   hyperon_state(hyp_state,sigma,ij,p);
+
+  // Set the process ID
+
+  // (quasi)elastic scatter 
+  if( (p1.pdg == PDG::pdg_Lambda && p[0].pdg == PDG::pdg_Lambda) || (PDG::Sigma(p1.pdg) && PDG::Sigma(p[0].pdg)) ) k2 = 0;
+
+  // lambda -> sigma
+  else if(p1.pdg == PDG::pdg_Lambda && PDG::Sigma(p[0].pdg)) k2 = 1;
+
+  // sigma -> lambda
+  else if(PDG::Sigma(p1.pdg) && p[0].pdg == PDG::pdg_Lambda) k2 = 2;
+
+  else { std::cout << "Hyperon scatter error" << std::endl; exit(1); }
+
 
   if(ij == 0 || ij == 1)
   {
-    vec v = p2.v();
+     vec v = p2.v();
 
-    double Ek =  p1.Ek_in_frame (-v);
+     double Ek =  p1.Ek_in_frame (-v);
 
-    NN_angle->set_input_point( Ek );
+     NN_angle->set_input_point( Ek );
 
-    float A = NN_angle->get_value( 1+ij ); // 1 is ii, 2 is ij                           
-    float B = NN_angle->get_value( 3+ij ); // 3 is ii, 4 is ij                           
+     float A = NN_angle->get_value( 1+ij ); // 1 is ii, 2 is ij                           
+     float B = NN_angle->get_value( 3+ij ); // 3 is ii, 4 is ij                           
 
-    // std::cout << p1.pdg << "  " << p2.pdg << std::endl;                               
-
-    res=scatterAB (p1, p2, p[0], p[1], 0, 0, 0, A, B, 0, 0, 1) || hyperon_error(p1,p2,p);
+     res=scatterAB (p1, p2, p[0], p[1], 0, 0, 0, A, B, 0, 0, 1) || hyperon_error(p1,p2,p);
 
   }
   else
   {
-    res = scatter_n(n,p1,p2,p) || hyperon_error(p1,p2,p);
+     res = scatter_n(n,p1,p2,p) || hyperon_error(p1,p2,p);
   }
 
-  / /set the binding energy of the hyperon
-  p[0].set_fermi(p1.his_fermi);
-
+   // Set position of outgoing particles to match 
+   // final position of hyperon before scatter
+   p[0].r = p1.r;
+   p[1].r = p1.r;
+ 
   return  res;
 
 }
-/////////////////////////////////////////////
-// if scatter unable to generate kinematics set
-// initial state same as final
-// find sometimes that CMS energy calculated
+
+////////////////////////////////////////////////////////////////////////////
+// If scatter unable to generate kinematics set initial state same as final
+// Find sometimes that CMS energy calculated
 // in hyperon cascade.cc is different to the one used by sactter by
 // 1-2 MeV and interaction being attempted should have been allowed
-///////////////////////////////////////////
+////////////////////////////////////////////////////////////////////////////
 
 bool Interaction::hyperon_error(particle p1, particle p2,particle p[])
 {
-  //  std::cout << "hyperon scatter error" << std::endl;
-
   p[0] = p1;
   p[1] = p2;
-
-  //  std::cout << "failure" << std::endl;
 
   return 1;
 }
 
+////////////////////////////////////////
 
+int Interaction::hyperon_process_id()
+{
+  // 30 = elastic (lambda -> lambda or sigma -> sigma)
+  // 31 = lambda -> sigma
+  // 32 = sigma -> lambda
+  
+  return hyperon_+k2;
+}
+
+////////////////////////////////////////

--- a/src/Interaction.h
+++ b/src/Interaction.h
@@ -63,7 +63,11 @@ inline int kod(int i)
     case 23: return 7;
     case 25: return 8;
     case 24: return 11;
-    case 30: return 14; // process names have to be added
+    //C Thorpe: Adding hyperon processes
+    case 30: return 15; // hyperon (quasi)elastic
+    case 31: return 16; // hyperon lambda -> sigma
+    case 32: return 17; // hyperon sigma -> lambda
+	
     case 99: return 9;
     case 100: return 10;
     default: throw "invalid interaction code";
@@ -719,7 +723,8 @@ class Interaction
                                                    (table p) and the number of outgoing particles (n). */
     int process_id()                          //! Returns the process id.
     {
-      if(k1==hyperon_) return 30; // process names have to be added
+      if(k1==hyperon_)  return hyperon_process_id(); // C Thorpe: Added hyperon process ids
+    
       return k1==nucleon_ ? nucleon_process_id() : PD.process_id(); 
     }
     const char* process_name()                //! Returns the process name.
@@ -747,6 +752,7 @@ class Interaction
     bool   nucleon_dpp(        particle  p1, particle  p2, int &n, particle p[] );
                                               //!< Scattering of p1, p2 with double pion production.
     int         nucleon_process_id();
+    int         hyperon_process_id();
                                               //!< Returns the nucleon process id.
     const char* nucleon_process_name();
                                               //!< Returns the nucleon process name.
@@ -754,7 +760,7 @@ class Interaction
     //calculates nucleon/hyperon cross section
     void get_hyp_xsec(double &nY, double &pY, particle N, particle Y, double sigma[], int &hyp_state);
     //scatters hyperons, particles p1 and p2 into p[]
-    bool hyperon_scattering(int hyp_state, particle& p1, particle& p2, int &n, particle p[],
+    bool hyperon_scattering(int hyp_state, particle& p1, particle& p2,nucleus t, int &n, particle p[],
                            double sigma[], double sigma_p, double sigma_n);
     bool hyperon_error(particle p1, particle p2, particle p[]);
 };

--- a/src/dis/disevent.cc
+++ b/src/dis/disevent.cc
@@ -29,7 +29,7 @@ TPythia6 *pythia22 = new TPythia6 ();
 extern "C" int pycomp_ (const int *);
 
 void
-disevent (params & p, event & e, bool cc)
+disevent (params & p, event & e, nucleus &t, bool cc)
 {
 /////////////////initial parameters/////////////////////
   bool current = cc;		//cc==true for charge current , nc == false
@@ -170,8 +170,17 @@ double Meff2=Meff*Meff;
 //      Done by Jaroslaw Nowak
 //////////////////////////////////////////////
 
+
 //stabilne pi0
       pythia22->SetMDCY (pycomp_ (&pizero), 1, 0);
+
+	//C Thorpe: Stabalize hyperons
+      pythia22->SetMDCY ( pycomp_ (&DIS_PDG::Lambda) , 1, 0);
+      pythia22->SetMDCY ( pycomp_ (&DIS_PDG::Sigma) , 1, 0);
+      pythia22->SetMDCY ( pycomp_ (&DIS_PDG::SigmaP) , 1, 0);
+      pythia22->SetMDCY ( pycomp_ (&DIS_PDG::SigmaM) , 1, 0);
+
+
 
       pythia22->SetMSTU (20, 1);	//advirsory warning for unphysical flavour switch off
       pythia22->SetMSTU (23, 1);	//It sets counter of errors at 0
@@ -306,7 +315,21 @@ double Meff2=Meff*Meff;
 	  if (ks[i] == 1)	//condition for a real particle in the final state
 	    {
 	      e.out.push_back (part);
-	    }
+        
+              // C Thorpe: If a hyperon, check if it can be moved to its potential
+              if(PDG::hyperon(part.pdg)){
+
+                if(p.nucleus_target && t.p + t.n > 1) part.set_fermi(t.hyp_BE(e.in[1].r.length(),part.pdg));
+
+                 // Check if hyperon can be generated in potential (performed at start of cascade)
+                 if( part.Ek() + part.his_fermi < 0 ){
+                    e.weight = 0.;
+                    return;
+                 }
+
+              }
+
+            }
 	}
 
     

--- a/src/dis/disevent.cc
+++ b/src/dis/disevent.cc
@@ -180,6 +180,10 @@ double Meff2=Meff*Meff;
       pythia22->SetMDCY ( pycomp_ (&DIS_PDG::SigmaP) , 1, 0);
       pythia22->SetMDCY ( pycomp_ (&DIS_PDG::SigmaM) , 1, 0);
 
+      // C Thorpe: Stablize kaons
+      pythia22->SetMDCY ( pycomp_ (&DIS_PDG::Kplus) , 1, 0);
+      pythia22->SetMDCY ( pycomp_ (&DIS_PDG::Kzero) , 1, 0);
+      pythia22->SetMDCY ( pycomp_ (&DIS_PDG::Kminus) , 1, 0);
 
 
       pythia22->SetMSTU (20, 1);	//advirsory warning for unphysical flavour switch off

--- a/src/dis/disevent.h
+++ b/src/dis/disevent.h
@@ -4,7 +4,7 @@
 #include "event1.h"
 #include "params.h"
 
-void disevent (params & p, event & e, bool cc);
+void disevent (params & p, event & e, nucleus &t, bool cc);
 
 #endif
 

--- a/src/dis/dishadr.cc
+++ b/src/dis/dishadr.cc
@@ -35,6 +35,12 @@ dishadr (event & e, bool current, double hama, double entra)
   pythia2->SetMDCY (pycomp_ (&SigmaP), 1, 0);
   pythia2->SetMDCY (pycomp_ (&SigmaM), 1, 0);
 
+  // C Thorpe: Stablize kaons
+  pythia22->SetMDCY ( pycomp_ (&DIS_PDG::Kplus) , 1, 0);
+  pythia22->SetMDCY ( pycomp_ (&DIS_PDG::Kzero) , 1, 0);
+  pythia22->SetMDCY ( pycomp_ (&DIS_PDG::Kminus) , 1, 0);
+
+
   pythia2->SetMSTU (20, 1);	//advirsory warning for unphysical flavour switch off
   pythia2->SetMSTU (23, 1);	//It sets counter of errors at 0
   pythia2->SetMSTU (26, 0);	//no warnings printed 

--- a/src/dis/dishadr.cc
+++ b/src/dis/dishadr.cc
@@ -29,6 +29,11 @@ dishadr (event & e, bool current, double hama, double entra)
 
 //stabilne pi0
   pythia2->SetMDCY (pycomp_ (&pizero), 1, 0);
+//C Thorpe: Adding Hyperons as stable dis particles
+  pythia2->SetMDCY (pycomp_ (&Lambda), 1, 0);
+  pythia2->SetMDCY (pycomp_ (&Sigma), 1, 0);
+  pythia2->SetMDCY (pycomp_ (&SigmaP), 1, 0);
+  pythia2->SetMDCY (pycomp_ (&SigmaM), 1, 0);
 
   pythia2->SetMSTU (20, 1);	//advirsory warning for unphysical flavour switch off
   pythia2->SetMSTU (23, 1);	//It sets counter of errors at 0

--- a/src/dis/pdg_name.h
+++ b/src/dis/pdg_name.h
@@ -40,6 +40,11 @@ const int Delta_plus = 2214;
 const int Delta_plusplus = 2224;
 const int Delta_minus = 1114;
 
+const int Lambda = 3122;
+const int Sigma = 3212;
+const int SigmaP = 3222;
+const int SigmaM = 3212;
+
 const int e = 11;
 const int nu_e = 12;
 const int mu = 13;
@@ -62,6 +67,9 @@ const double Dsplus_mass = 1.968;
 const double Dzero_mass = 1.8646;
 const double Dplus_mass = 1.8694;
 const double Lambda_mass = 1.1157;
+const double SigmaP_mass = 1.18937;
+const double SigmaM_mass = 1.19745;
+const double Sigma_mass = 1.19264;
 const double mass_e = 0.000510999 * 1000;
 const double mass_mu = 0.105658 * 1000;
 const double mass_tau = 1.77699 * 1000;

--- a/src/dis/pdg_name.h
+++ b/src/dis/pdg_name.h
@@ -30,6 +30,7 @@ const int piplus = 211;
 const int piminus = -211;
 const int Kplus = 321;
 const int Kzero = 311;
+const int Kminus = -321;
 const int Dsplus = 431;
 const int Dsminus = -431;
 const int Dzero = 421;

--- a/src/dis/reshadr.cc
+++ b/src/dis/reshadr.cc
@@ -30,8 +30,15 @@ reshadr (event & e, bool current, double hama, double entra, double rel0,
 //      Done by Jaroslaw Nowak
 //////////////////////////////////////////////
 
+std::cout << "Setting RES PYTHIA parameters" << std::endl;
+
 //stabilne pi0
   pythia7->SetMDCY (pycomp_ (&pizero), 1, 0);
+//C Thorpe: Adding Hyperons as stable dis particles
+  pythia7->SetMDCY (pycomp_ (&Lambda), 1, 0);
+  pythia7->SetMDCY (pycomp_ (&Sigma), 1, 0);
+  pythia7->SetMDCY (pycomp_ (&SigmaP), 1, 0);
+  pythia7->SetMDCY (pycomp_ (&SigmaM), 1, 0);
 
   pythia7->SetMSTU (20, 1);	//advirsory warning for unphysical flavour switch off
   pythia7->SetMSTU (23, 1);	//It sets counter of errors at 0

--- a/src/dis/reshadr.cc
+++ b/src/dis/reshadr.cc
@@ -34,11 +34,17 @@ std::cout << "Setting RES PYTHIA parameters" << std::endl;
 
 //stabilne pi0
   pythia7->SetMDCY (pycomp_ (&pizero), 1, 0);
-//C Thorpe: Adding Hyperons as stable dis particles
+
+  //C Thorpe: Adding Hyperons as stable dis particles
   pythia7->SetMDCY (pycomp_ (&Lambda), 1, 0);
   pythia7->SetMDCY (pycomp_ (&Sigma), 1, 0);
   pythia7->SetMDCY (pycomp_ (&SigmaP), 1, 0);
   pythia7->SetMDCY (pycomp_ (&SigmaM), 1, 0);
+
+  // C Thorpe: Stablize kaons
+  pythia22->SetMDCY ( pycomp_ (&DIS_PDG::Kplus) , 1, 0);
+  pythia22->SetMDCY ( pycomp_ (&DIS_PDG::Kzero) , 1, 0);
+  pythia22->SetMDCY ( pycomp_ (&DIS_PDG::Kminus) , 1, 0);
 
   pythia7->SetMSTU (20, 1);	//advirsory warning for unphysical flavour switch off
   pythia7->SetMSTU (23, 1);	//It sets counter of errors at 0

--- a/src/event1.h
+++ b/src/event1.h
@@ -53,7 +53,7 @@ class event:public TObject
 		                        ///< 8,9 - mec  cc/nc - meson exhchange current   
 		                        ///< 20 -  eel  nc - elastic electron scattering 
 
-		int nod[15];            ///< number of rescattering interactions of given type:
+		int nod[18];            ///< number of rescattering interactions of given type:
 		                        ///< 0 - nucleon elastic,
 		                        ///< 1 - nucleon ce,
 		                        ///< 2 - nucleon spp,
@@ -68,7 +68,10 @@ class event:public TObject
 		                        ///< 11 - pion tpp
 		                        ///< 12 - pion no interaction
 		                        ///< 13 - nucleon no interaction
-														///< 14 - any hyperon
+					///< 14 - hyperon no interaction
+					///< 15 - hyperon elastic scatter
+					///< 16 - hyperon Lambda -> Sigma conversion
+					///< 17 - hyperon Sigma -> Lambda conversion
 		int pr;     ///< number of protons  in the residual nucleus
 		int nr;     ///< number of neutrons in the residual nucleus
 		double r_distance; //< distance from nucleus center of absorption point (if happened)

--- a/src/ff.cc
+++ b/src/ff.cc
@@ -23,6 +23,8 @@ static const double MA_cc_mec =
 static const double MA_nc_mec = 1014 * MeV;
 static double MA_s = 1030 * MeV;
 static double MA_hyp = 1030 * MeV; // C Thorpe Added Hyperon axial mass parameter
+
+static const double Dipole_Lambda = 5.6; //C Thorpe: Lambda parameter used in dipole form factors
                                    // default 1030 MeV // March 2019
 static double delta_s = 0;
 static const double mu_p = 2.793;   // moment dipolowy protonu
@@ -269,11 +271,14 @@ FF DipoleFF(const double q2)  // dipole electric form factor G_E^V
 {
   double a = 1.0 - q2 / MV2;
   double a2 = a * a;
+  double tau = -q2 / (4 * M2);
 
   FF ff;
   ff.Q2 = -q2;
   ff.GEp = 1.0 / a2;
-  ff.GEn = 0;
+  //  ff.GEn = 0;
+  //C Thorpe: Updated dipole FFs
+  ff.GEn = (-1)*mu_n*tau/(1+Dipole_Lambda*tau)/a2;
   ff.GMp = mu_p / a2;
   ff.GMn = mu_n / a2;
 

--- a/src/geomy.h
+++ b/src/geomy.h
@@ -67,20 +67,23 @@ class geomy
 	TGeoElement* ele1;
 
 
-//C Thorpe: reads in length units from params file, used in density calculations
+// C Thorpe: reads in length units from params file, used in density calculations
 public:
 	geomy(std::string _filename, std::string _geoname,std::string geom_length_units, double geom_density_convert, std::string volume="", vec _d = vec(0,0,0), vec _o = vec(0,0,0) )
 	{		
 
-	//C Thorpe: Factor to convert density to g/cm3 - required value has been added to ND280 geom.txt file
+	// C Thorpe: Factor to convert density to g/cm3 - required value has been added to ND280 geom.txt file
+	// Default value is 1
 	density_convert=geom_density_convert;
 		
-	//set length scaling based on units provided
+	// Set length scaling based on units provided
 	if(geom_length_units == "mm") length_scale = 0.1;
 	else if(geom_length_units == "cm") length_scale = 1;
 	else if(geom_length_units == "m") length_scale = 10;
-	else
-	std::cout << "Unrecognised geometry length units: " << geom_length_units  << std::endl<< "Use either mm, cm or m" << std::endl;
+	else {
+	std::cout << "Unrecognised geometry length units: " << geom_length_units  << std::endl << "Use either mm, cm or m" << std::endl;
+        exit(1);
+        }
 
 	pots=npots=0;
 
@@ -174,9 +177,6 @@ public:
 			}
 
 			  	
-			for(int i=0;i<n;i++){
-			  //  std::cout << mix1->GetAmixt()[i] << "   " << mix1->GetZmixt()[i] << "   " << w[i] << std::endl;
-			}
 			
 
 			tam.A = mix1->GetAmixt()[c];
@@ -185,7 +185,6 @@ public:
 		}
 		else	//if(ele1 == NULL)
 		{
-		  //  std::cout << "Not mixture" << std::endl;
 			tam.A = mat1->GetA();
 			tam.Z = mat1->GetZ();
 			tam.N = d_round(tam.A) - tam.Z;
@@ -193,16 +192,15 @@ public:
 		
 
 
-		//	double CLHEP_g_cm3=6.24151e+18;
+		//double CLHEP_g_cm3=6.24151e+18;
 			
-		//conversion factor to get density in g/cm3	
-		//for ND280 density_convert = 6.24151e+18;
+		// Conversion factor to get density in g/cm3	
+		// for ND280 density_convert = 6.24151e+18;
 		tam.w_density = mat1->GetDensity()/density_convert;
 
 		dens+=tam.w_density;
 		ndens++;
 		max_density = max(max_density,tam.w_density);
-//		std::cout << nuc[0] << std::endl;
 		nuc[0]+=tam.N*tam.w_density/(tam.N+tam.Z);
 		nuc[1]+=tam.Z*tam.w_density/(tam.N+tam.Z);
 		tam.r = r;
@@ -214,6 +212,8 @@ public:
 		double x,dx,y,dy,z,dz;
 	    x=y=z=0;
 	    dx=dy=dz=1e40;
+		
+
 		if(dir.x!=0)
 		{  x=(orig.x-start.x)/dir.x;
 		   dx=abs(dxyz.x/dir.x);
@@ -256,9 +256,9 @@ public:
 		double tb=min(x+dx,min(y+dy,z+dz));
 		if(tb>ta)
 		 { 
-			//C Thorpe: Check geom units, convert to cm
+			// C Thorpe: Check geom units, convert to cm
 			 
-			double len=dir.length()*(tb-ta)*length_scale; //length scale takes geom length units and converts to cm
+			double len=dir.length()*(tb-ta)*length_scale; // Length scale takes geom length units and converts to cm
 	
 		    if(len>frandom()*max_length)
 		      {
@@ -270,19 +270,15 @@ public:
 		 }
 		double mol=6.02214129e23 ;
 
-		/* density is in g/cm3 
-		*  length is in cm
+		/* Density is in g/cm3 
+		*  Length is in cm
 		*  mol = number of nucleons per gram
 		*  pots is in nucleons/cm2
 		*/ 
-		//CT: this density is wrong - off by many OM
-		// max_length is in cm, tam.w_density is in g/cm3
 		
 		pots+=tam.w_density*max_length*mol;
 		npots++;  
 		
-
-		//	std::cout << npots << std::endl;
 		//~ cout<<tam.w_density/CLHEP_g_cm3<<'\t';
 		//~ cout<<tam.A<<'\t';
 		//~ cout<<tam.Z<<'\t';
@@ -315,10 +311,8 @@ public:
 	
 	double vol_mass()
 	{
-	 	//C Thorpe: Lengths should be in cm and density in g/cm3 for all configurations 
-	 
-	return 8*dxyz.x*dxyz.y*dxyz.z*density()*length_scale*length_scale*length_scale*cm3; 
-
+           // C Thorpe: Lengths should be in cm and density in g/cm3 for all configurations 	 
+           return 8*dxyz.x*dxyz.y*dxyz.z*density()*length_scale*length_scale*length_scale*cm3; 
 	}
 
 	double frac_proton()

--- a/src/hyperon_cascade.cc
+++ b/src/hyperon_cascade.cc
@@ -24,676 +24,697 @@
 
 //////////////////////////////////////////////
 
-
-///////////////////////////////////////////////////
-// Setup the cross section data and store in sigma[]
-
 /*
-Argument list:
+   Setup the cross section data and store in sigma[]
+   Argument list:
 
-E = CMS energy
-Plab = hyperon momentum in nucleon rest frame
-sigma[] = stores hyperon/nucleon cross sections
-hyp_state = indicates the initial state 
+   E = CMS energy
+   Plab = hyperon momentum in nucleon rest frame
+   sigma[] = stores hyperon/nucleon cross sections
+   hyp_state = indicates the initial state 
 
- */
+*/
 
- 
 ///////////////////////////////////////////////////
 
 void hyperon_exp_xsec(double E, double Plab, double sigma[] , int hyp_state){
 
- 
+   bool Print = false; 
 
-  //momentum in  units of GeV
-  //convert from MeV to GeV
-  Plab /= GeV; 
-  double x;
-
-  //EVERYTHING ELSE IN MeV 
-  // all calculations except for sigma 1-4 are dimensionless 
-  // phase space ratios so as long as the units used for R are the same 
-  // then its is safe to use different units 
-
-  if(Plab > 2.1){x = 2.1;}
-  else {x=Plab;}
-
- 
-  double M_N1; //initial nucleon mass
-  double M_N2; //final nucleon mass
-  double M_L = PDG::mass_Lambda; //lambda mass
-  double M_S; // sigma mass
-
-  //CMS momentum ratio (used as a phase space correction)
-  double R;
-  
-
-  //Singh and Vicente Vacas fits
-  double sigma_1 = (39.66 - 100.45*x + 92.44*x*x - 21.4*x*x*x)/(Plab)*millibarn;
-  double sigma_2 =  (31.1 - 30.94*x + 8.16*x*x)*millibarn;
-  double sigma_3 = (11.77/Plab + 19.07)*millibarn;
-  double sigma_4 =  (22.4/Plab - 1.08)*millibarn;
+   //momentum in  units of GeV
+   //convert from MeV to GeV
+   Plab /= GeV; 
+   double x;
 
 
+   //EVERYTHING ELSE IN MeV 
+   // all calculations except for sigma 1-4 are dimensionless 
+   // phase space ratios so as long as the units used for R are the same 
+   // then its is safe to use different units 
 
-  // check what final states are energetically accessible
-  // and set cross sections
-
-  /////////////////////////////////////////////////////////////////////
-  // INITIAL HYPERON LAMBDA 
-  /////////////////////////////////////////////////////////////////////////
-
-  if(hyp_state == 0 || hyp_state == 4){
-
-    //first cross section is always accessible
-    //set elastic cross sections sigma[0] and sigma[3]
-
-    /////////////////////////////////
-    // LAMBDA P -> LAMBDA P
-    ////////////////////////////////
-    sigma[0] = sigma_1;
-
-   
-    /////////////////////////////
-    // LAMBDA N -> LAMBDA N
-    //////////////////////////////
-    sigma[3] = sigma[0];
+   if(Plab > 2.1){x = 2.1;}
+   else {x=Plab;}
 
 
-    //////////////////////////////////
-    // LAMBDA P -> SIGMA+ N
-    ///////////////////////////////////
-   
-    E = cms_energy(Plab*GeV,PDG::mass_proton,PDG::mass_Lambda);
+   double M_N1; //initial nucleon mass
+   double M_N2; //final nucleon mass
+   double M_L = PDG::mass_Lambda; //lambda mass
+   double M_S; // sigma mass
 
-    if(E > (PDG::mass_SigmaP + PDG::mass_neutron)){
+   //CMS momentum ratio (used as a phase space correction)
+   double R;
 
-      M_S = PDG::mass_SigmaP;
-      M_N1 = PDG::mass_proton;
-      M_N2 = PDG::mass_neutron;
 
-    
+   //Singh and Vicente Vacas fits
+   double sigma_1 = (39.66 - 100.45*x + 92.44*x*x - 21.4*x*x*x)/(Plab)*millibarn;
+   double sigma_2 =  (31.1 - 30.94*x + 8.16*x*x)*millibarn;
+   double sigma_3 = (11.77/Plab + 19.07)*millibarn;
+   double sigma_4 =  (22.4/Plab - 1.08)*millibarn;
 
-      R=phase_space(E,M_S,M_N2,M_L,M_N1);
-     
 
-      	sigma[1] = 2*sigma_2*R;
 
- 
+   // check what final states are energetically accessible
+   // and set cross sections
+
+   /////////////////////////////////////////////////////////////////////
+   // INITIAL HYPERON LAMBDA 
+   /////////////////////////////////////////////////////////////////////////
+
+   if(hyp_state == 0 || hyp_state == 4){
+
+      double KE = (sqrt(Plab*Plab*1e6 + PDG::mass_Lambda*PDG::mass_Lambda) - PDG::mass_Lambda)/1e3;
+
+      //first cross section is always accessible
+      //set elastic cross sections sigma[0] and sigma[3]
+
+      /////////////////////////////////
+      // LAMBDA P -> LAMBDA P
+      ////////////////////////////////
+      sigma[0] = sigma_1;
+      if(Print) std::cout << "LZ+P to LZ+P " << Plab << " " << KE << " " << sigma[0] << std::endl;
+
+      /////////////////////////////
+      // LAMBDA N -> LAMBDA N
+      //////////////////////////////
+      sigma[3] = sigma[0];
+      if(Print) std::cout << "LZ+N to LZ+N " << Plab << " " << KE << " " << sigma[3] << std::endl;
+
       //////////////////////////////////
-      // LAMBDA P -> SIGMA0 P
-      //////////////////////////////////
+      // LAMBDA P -> SIGMA+ N
+      ///////////////////////////////////
 
- 
+      E = cms_energy(Plab*GeV,PDG::mass_proton,PDG::mass_Lambda);
 
-      if(E > (PDG::mass_Sigma + PDG::mass_proton)){
+      if(E > (PDG::mass_SigmaP + PDG::mass_neutron)){
 
-	M_N1 = PDG::mass_proton;
-	M_N2 = PDG::mass_proton;
-	M_S = PDG::mass_Sigma;
+         M_S = PDG::mass_SigmaP;
+         M_N1 = PDG::mass_proton;
+         M_N2 = PDG::mass_neutron;
 
-      
-	R = phase_space(E,M_S,M_N2,M_L,M_N1);
 
-	  sigma[2] = sigma_2*R;
+
+         R=phase_space(E,M_S,M_N2,M_L,M_N1);
+
+
+         sigma[1] = 2*sigma_2*R;
+         if(Print) std::cout << "LZ+P to SP+N " << Plab << " " << KE << " " << sigma[1] << std::endl;
+
+
+         //////////////////////////////////
+         // LAMBDA P -> SIGMA0 P
+         //////////////////////////////////
+
+
+
+         if(E > (PDG::mass_Sigma + PDG::mass_proton)){
+
+            M_N1 = PDG::mass_proton;
+            M_N2 = PDG::mass_proton;
+            M_S = PDG::mass_Sigma;
+
+
+            R = phase_space(E,M_S,M_N2,M_L,M_N1);
+
+            sigma[2] = sigma_2*R;
+            if(Print) std::cout << "LZ+P to SZ+P " << Plab << " " << KE << " " << sigma[2] << std::endl;
+
+         }
+         else {sigma[2] = 0;}
 
       }
-      else {sigma[2] = 0;}
-
-    }
-    else {sigma[1]=0; sigma[2] = 0;}
+      else {sigma[1]=0; sigma[2] = 0;}
 
 
-    ///////////////////////////////
-    // LAMBDA N -> SIGMA0 N
-    ////////////////////////////////
+      ///////////////////////////////
+      // LAMBDA N -> SIGMA0 N
+      ////////////////////////////////
 
- E = cms_energy(Plab*GeV,PDG::mass_neutron,PDG::mass_Lambda);
+      E = cms_energy(Plab*GeV,PDG::mass_neutron,PDG::mass_Lambda);
 
-    if(E > (PDG::mass_Sigma + PDG::mass_neutron)){
+      if(E > (PDG::mass_Sigma + PDG::mass_neutron)){
 
-      M_N1 = PDG::mass_neutron;
-      M_N2 = PDG::mass_neutron;
-      M_S = PDG::mass_Sigma;
+         M_N1 = PDG::mass_neutron;
+         M_N2 = PDG::mass_neutron;
+         M_S = PDG::mass_Sigma;
 
-      //	E = cms_energy(Plab*GeV,M_N1,M_L);
+         //	E = cms_energy(Plab*GeV,M_N1,M_L);
 
-      	R = phase_space(E,M_S,M_N2,M_L,M_N1);
-   
-	sigma[4] = sigma_2*R;
+         R = phase_space(E,M_S,M_N2,M_L,M_N1);
 
-	//	std::cout << "sigma4: " << sigma[4] << std::endl;
-	
+         sigma[4] = sigma_2*R;
+         if(Print) std::cout << "LZ+N to SZ+N " << Plab << " " << KE << " " << sigma[4] << std::endl;
+
+         //	std::cout << "sigma4: " << sigma[4] << std::endl;
 
 
-      ////////////////////////////////////////
-      // LAMBDA N -> SIGMA- P
+         ////////////////////////////////////////
+         // LAMBDA N -> SIGMA- P
+         //////////////////////////////////////
+
+         if(E > (PDG::mass_SigmaM + PDG::mass_proton)){
+
+            M_S = PDG::mass_SigmaM;
+            M_N1 = PDG::mass_neutron;
+            M_N2 = PDG::mass_proton;
+
+            //	E = cms_energy(Plab*GeV,M_N1,M_L);
+
+            R = phase_space(E,M_S,M_N2,M_L,M_N1);
+
+
+            sigma[5] = 2*sigma_2*R;
+            if(Print) std::cout << "LZ+N to SM+P " << Plab << " " << KE << " " << sigma[5] << std::endl;
+
+            //	std::cout << "sigma5: " << sigma[5] << std::endl;
+
+         }
+         else {sigma[5] = 0;}
+
+      }
+
+      else {sigma[4] = 0; sigma[5] = 0;}
+   }
+
+
+   //////////////////////////////////////////////////////////////////////////////
+   // INITIAL HYPERON SIGMA0 
+   ///////////////////////////////////////////////////////////////////////////////
+
+   //sigma0 and proton or neutron in initial state
+   else if(hyp_state == 1 || hyp_state == 5){
+      //all final states are energetically accessible at any momentum
+
+      double KE = (sqrt(Plab*Plab*1e6 + PDG::mass_Sigma*PDG::mass_Sigma) - PDG::mass_Sigma)/1e3;
+
+      E = cms_energy(Plab*GeV,PDG::mass_proton,PDG::mass_Sigma);
+
+      //////////////////////////
+      // SIGMA0 P -> SIGMA0 P
+      ///////////////////////////
+
+      sigma[0] = sigma_4; //sigma0 p -> sigma0 p 
+      if(Print) std::cout << "SZ+P to SZ+P " << Plab << " " << KE << " " << sigma[0] << std::endl;
+
+
+      ////////////////////////////////////
+      // SIGMA 0 P -> LAMBDA P
       //////////////////////////////////////
 
+      M_S = PDG::mass_Sigma;
+      M_N1 = PDG::mass_proton;
+      M_N2 = PDG::mass_proton;
+
+      R = phase_space(E,M_L,M_N2,M_S,M_N1);
+
+      sigma[1] = sigma_2*R;
+      if(Print) std::cout << "SZ+P to LZ+P " << Plab << " " << KE << " " << sigma[1] << std::endl;
+
+
+      //////////////////////////////////
+      // SIGMA0 P -> SIGMA+ N 
+      /////////////////////////////////
+
+      sigma[2] = sigma_4; 
+      if(Print) std::cout << "SZ+P to SP+N " << Plab << " " << KE << " " << sigma[2] << std::endl;
+
+      /////////////////////////////////////
+      // SIGMA0 N -> SIGMA0 N
+      /////////////////////////////////////
+
+      E = cms_energy(Plab*GeV,PDG::mass_neutron,PDG::mass_Sigma);
+
+      sigma[3] = sigma_4; //sigma0 n -> sigma0 n
+      if(Print) std::cout << "SZ+N to SZ+N " << Plab << " " << KE << " " << sigma[3] << std::endl;
+
+      ////////////////////////////////////
+      //SIGMA0 N -> LAMBDA N
+      ////////////////////////////////
+
+      sigma[4] = sigma[1];
+      if(Print) std::cout << "SZ+N to LZ+N " << Plab << " " << KE << " " << sigma[4] << std::endl;
+
+      ///////////////////////////////////////
+      // SIGMA0 N -> SIGMA- P
+      /////////////////////////////////////
+
       if(E > (PDG::mass_SigmaM + PDG::mass_proton)){
-
-	M_S = PDG::mass_SigmaM;
-	M_N1 = PDG::mass_neutron;
-	M_N2 = PDG::mass_proton;
-
-	//	E = cms_energy(Plab*GeV,M_N1,M_L);
-
-	R = phase_space(E,M_S,M_N2,M_L,M_N1);
-      
-
-	  sigma[5] = 2*sigma_2*R;
-
-	  //	std::cout << "sigma5: " << sigma[5] << std::endl;
-
+         sigma[5] = sigma_4;
+         if(Print) std::cout << "SZ+N to SM+P " << Plab << " " << KE << " " << sigma[5] << std::endl;
       }
       else {sigma[5] = 0;}
 
-    }
+   }
 
-    else {sigma[4] = 0; sigma[5] = 0;}
-  }
+   ////////////////////////////////////////////////////////////////////////////////////////
+   // SIGMA MINUS INITIAL HYPERON
+   ///////////////////////////////////////////////////////////////////////////////////////
 
+   else if(hyp_state == 2 || hyp_state == 6){
 
-  //////////////////////////////////////////////////////////////////////////////
-  // INITIAL HYPERON SIGMA0 
-  ///////////////////////////////////////////////////////////////////////////////
+      double KE = (sqrt(Plab*Plab*1e6 + PDG::mass_SigmaM*PDG::mass_SigmaM) - PDG::mass_SigmaM)/1e3;
 
-  //sigma0 and proton or neutron in initial state
-  else if(hyp_state == 1 || hyp_state == 5){
-    //all final states are energetically accessible at any momentum
+      E = cms_energy(Plab*GeV,PDG::mass_proton,PDG::mass_SigmaM);
 
+      /////////////////////////
+      // SIGMA- P -> SIGMA- P
+      /////////////////////////
 
-E = cms_energy(Plab*GeV,PDG::mass_proton,PDG::mass_Sigma);
+      sigma[0] = sigma_4;
+      if(Print) std::cout << "SM+P to SM+P " << Plab << " " << KE << " " << sigma[0] << std::endl;
 
-    //////////////////////////
-    // SIGMA0 P -> SIGMA0 P
-    ///////////////////////////
+      ///////////////////////////
+      // SIGMA- P -> LAMBDA N
+      //////////////////////////
 
-    sigma[0] = sigma_4; //sigma0 p -> sigma0 p 
+      M_S = PDG::mass_SigmaM;
+      M_N1 = PDG::mass_proton;
+      M_N2 = PDG::mass_neutron;
 
+      R = phase_space(E,M_L,M_N2,M_S,M_N1);
 
-    ////////////////////////////////////
-    // SIGMA 0 P -> LAMBDA P
-    //////////////////////////////////////
+      sigma[1] = 2*sigma_2*R; //sigmaM p -> Lambda n
+      if(Print) std::cout << "SM+P to LZ+N " << Plab << " " << KE << " " << sigma[1] << std::endl;
 
-    M_S = PDG::mass_Sigma;
-  M_N1 = PDG::mass_proton;
-  M_N2 = PDG::mass_proton;
- 
-	R = phase_space(E,M_L,M_N2,M_S,M_N1);
+      //////////////////////////
+      // SIGMA- P -> SIGMA0 N
+      ////////////////////////
 
-    sigma[1] = sigma_2*R;
-  
-    //////////////////////////////////
-    // SIGMA0 P -> SIGMA+ N 
-    /////////////////////////////////
 
-    sigma[2] = sigma_4; 
+      sigma[2] = sigma_4; //sigmaM p -> Sigma0 n 
+      if(Print) std::cout << "SM+P to SZ+N " << Plab << " " << KE << " " << sigma[2] << std::endl;
 
-    /////////////////////////////////////
-    // SIGMA0 N -> SIGMA0 N
-    /////////////////////////////////////
+      /////////////////////////////////
+      // SIGMA- N -> SIGMA- N
+      ////////////////////////////////
 
-E = cms_energy(Plab*GeV,PDG::mass_neutron,PDG::mass_Sigma);
+      E = cms_energy(Plab*GeV,PDG::mass_neutron,PDG::mass_SigmaM);
 
-    sigma[3] = sigma_4; //sigma0 n -> sigma0 n
+      sigma[3] = sigma_3; //sigmaM n -> sigmaM n 
+      if(Print) std::cout << "SM+N to SM+N " << Plab << " " << KE << " " << sigma[3] << std::endl;
 
-    ////////////////////////////////////
-    //SIGMA0 N -> LAMBDA N
-    ////////////////////////////////
+      /////////////////////////////////
 
-    sigma[4] = sigma[1];
-    
-    ///////////////////////////////////////
-    // SIGMA0 N -> SIGMA- P
-    /////////////////////////////////////
+      //no other final states for sigmaM and neutron
+      sigma[4] = 0;
+      sigma[5] = 0;
 
-    if(E > (PDG::mass_SigmaM + PDG::mass_proton)){
-      sigma[5] = sigma_4;
-    }
-    else {sigma[5] = 0;}
+   }
 
-  }
+   ///////////////////////////////////////////////////////////////////////////////////////
+   // INITIAL HYPERON SIGMA PLUS 
+   //////////////////////////////////////////////////////////////////////////////////////
 
-  ////////////////////////////////////////////////////////////////////////////////////////
-  // SIGMA MINUS INITIAL HYPERON
-  ///////////////////////////////////////////////////////////////////////////////////////
 
- else if(hyp_state == 2 || hyp_state == 6){
+   else if(hyp_state == 3 || hyp_state == 7){
 
-E = cms_energy(Plab*GeV,PDG::mass_proton,PDG::mass_SigmaM);
+      double KE = (sqrt(Plab*Plab*1e6 + PDG::mass_SigmaP*PDG::mass_SigmaP) - PDG::mass_SigmaP)/1e3;
 
-   /////////////////////////
-   // SIGMA- P -> SIGMA- P
-   /////////////////////////
+      E = cms_energy(Plab*GeV,PDG::mass_proton,PDG::mass_SigmaP);
 
-   sigma[0] = sigma_4;
+      M_S = PDG::mass_SigmaP;
 
-   ///////////////////////////
-   // SIGMA- P -> LAMBDA N
-   //////////////////////////
 
-   M_S = PDG::mass_SigmaM;
-   M_N1 = PDG::mass_proton;
-   M_N2 = PDG::mass_neutron;
 
-   R = phase_space(E,M_L,M_N2,M_S,M_N1);
+      /////////////////////////////
+      // SIGMA+ P -> SIGMA+ P
+      /////////////////////////////
 
-   sigma[1] = 2*sigma_2*R; //sigmaM p -> Lambda n
+      sigma[0] = sigma_3; //sigmaP p -> sigmaP p
+      if(Print) std::cout << "SP+P to SP+P " << Plab << " " << KE << " " << sigma[0] << std::endl;
 
-   //////////////////////////
-   // SIGMA- P -> SIGMA0 N
-   ////////////////////////
 
+      ////////////////////////////
 
-   sigma[2] = sigma_4; //sigmaM p -> Sigma0 n 
+      //no other final states for sigmaP proton
+      sigma[1] = 0;
+      sigma[2] = 0;
 
-   /////////////////////////////////
-   // SIGMA- N -> SIGMA- N
-   ////////////////////////////////
+      /////////////////////////
+      // SIGMA+ N -> SIGMA+ N 
+      ///////////////////////////
 
-   E = cms_energy(Plab*GeV,PDG::mass_neutron,PDG::mass_SigmaM);
+      E = cms_energy(Plab*GeV,PDG::mass_neutron,PDG::mass_SigmaP);
 
-   sigma[3] = sigma_3; //sigmaM n -> sigmaM n 
+      sigma[3] = sigma_4; //sigmaP n -> sigmaP n 
+      if(Print) std::cout << "SP+N to SP+N " << Plab << " " << KE << " " << sigma[3] << std::endl;
 
-   /////////////////////////////////
+      /////////////////////////////
+      // SIGMA+ N -> LAMBDA P
+      ////////////////////////////
 
-   //no other final states for sigmaM and neutron
-   sigma[4] = 0;
-   sigma[5] = 0;
+      M_N1 = PDG::mass_neutron;
+      M_N2 = PDG::mass_proton;
 
- }
+      R = phase_space(E,M_L,M_N2,M_S,M_N1);
 
-  ///////////////////////////////////////////////////////////////////////////////////////
-  // INITIAL HYPERON SIGMA PLUS 
-  //////////////////////////////////////////////////////////////////////////////////////
+      sigma[4] = 2*sigma_2*R; //sigmaP n -> lambda p 
+      if(Print) std::cout << "SP+N to LZ+P " << Plab << " " << KE << " " << sigma[4] << std::endl;
 
+      /////////////////////////////
+      // SIGMA+ N -> Sigma0 P
+      ////////////////////////////
 
- else if(hyp_state == 3 || hyp_state == 7){
+      //no third reaction for this initial state
+      sigma[5] = 0;
 
-   E = cms_energy(Plab*GeV,PDG::mass_proton,PDG::mass_SigmaP);
+      ////////////////////////////////////////////////////////////////////////////////////////////
 
-   M_S = PDG::mass_SigmaP;
+   }
 
-
-
-   /////////////////////////////
-   // SIGMA+ P -> SIGMA+ P
-   /////////////////////////////
-
-   sigma[0] = sigma_3; //sigmaP p -> sigmaP p
-
-
-   ////////////////////////////
-
-   //no other final states for sigmaP proton
-   sigma[1] = 0;
-   sigma[2] = 0;
-
-   /////////////////////////
-   // SIGMA+ N -> SIGMA+ N 
-   ///////////////////////////
-
-   E = cms_energy(Plab*GeV,PDG::mass_neutron,PDG::mass_SigmaP);
-
-   sigma[3] = sigma_4; //sigmaP n -> sigmaP n 
-
-   /////////////////////////////
-   // SIGMA+ N -> LAMBDA P
-   ////////////////////////////
-
-   M_N1 = PDG::mass_neutron;
-   M_N2 = PDG::mass_proton;
-
-
-
-   R = phase_space(E,M_L,M_N2,M_S,M_N1);
-
-	
-
-   sigma[4] = 2*sigma_2*R; //sigmaP n -> lambda p 
-
-  
-  
-
-   ////////////////////////
-
-   //no third reaction for this initial state
-   sigma[5] = 0;
-
-   ////////////////////////////////////////////////////////////////////////////////////////////
-
- }
-
- else
+   else
    { 
-     for(int i=0;i<6;i++)
-       {
-	 std::cout << "hyperon cross section error" << std::endl;
-	 sigma[i] = 0;
-       }	   
+      for(int i=0;i<6;i++)
+      {
+         std::cout << "hyperon cross section error" << std::endl;
+         sigma[i] = 0;
+      }	   
    }
 
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////
-// select final state based on cross sections 
-// and what the initial hypeorn-nucleon state is
 
-/* Argument list
+/*
+   Select final state based on cross sections and what the initial hyperon-nucleon state is
 
-hyp_state contains information about the initial pair of particles
-sigma[] the list of hyperon-nucleon cross sections 
-ij argument given to scattering code to select differential cross sections
-p[] array containing the final particles
+   Argument list
 
-
- */
+   hyp_state contains information about the initial pair of particles
+   sigma[] the list of hyperon-nucleon cross sections 
+   ij argument given to scattering code to select differential cross sections
+   p[] array containing the final particles
+   */
 
 ///////////////////////////////////////////////////////////////////////////////////////
 
 void hyperon_state(int hyp_state,double sigma[],int &ij, particle p[]){
 
 
-  //decide how to shape the cross sections based on the electric charges
-  //of the initial/final state particles and if they
-  //have a matching p/n interaction process
+   // Decide how to shape the cross sections based on the electric charges
+   // of the initial/final state particles and if they
+   // have a matching p/n interaction process
 
-  //ij are set as follows
-  //0 if process is either ++ -> ++ or 00 -> 00 
-  //1 if process is either  +0 -> 0+ or 0- -> 0- 
-  //2 for all other combinations
-
- 
-  //generate random number 
-  double R = frandom();
-
-  double sigma_p = sigma[0]+sigma[1]+sigma[2]; //hyperon-proton total cross section
-  double sigma_n = sigma[3]+sigma[4]+sigma[5]; //hyperon-neutron total cross section
-
-  //lambda proton
-  if(hyp_state == 0){
-
- 
-    //final state is sigma0 p 
-    if(R > ((sigma[0] + sigma[1])/sigma_p)){
-
-      p[0].set_pdg_and_mass(PDG::pdg_Sigma,PDG::mass_Sigma);
-      p[1].set_pdg_and_mass(PDG::pdg_proton,PDG::mass_proton);
-
-      ij = 1;
-
-    }
-    //final state is sigmaP n    
-    else if(R > (sigma[0]/sigma_p)){
-
-   
-
-      p[0].set_pdg_and_mass(PDG::pdg_SigmaP,PDG::mass_SigmaP);
-      p[1].set_pdg_and_mass(PDG::pdg_neutron,PDG::mass_neutron);
-
-      ij = 1;
-
-    }
-    //final state is lambda p
-    else {
+   // ij are set as follows
+   // 0 if process is either ++ -> ++ or 00 -> 00 
+   // 1 if process is either  +0 -> 0+ or 0- -> 0- 
+   // 2 for all other combinations
 
 
-      ij=1;
+   //generate random number 
+   double R = frandom();
 
-      p[0].set_pdg_and_mass(PDG::pdg_Lambda,PDG::mass_Lambda);
-      p[1].set_pdg_and_mass(PDG::pdg_proton,PDG::mass_proton);
+   double sigma_p = sigma[0]+sigma[1]+sigma[2]; //hyperon-proton total cross section
+   double sigma_n = sigma[3]+sigma[4]+sigma[5]; //hyperon-neutron total cross section
+
+   //lambda proton
+   if(hyp_state == 0){
 
 
-    }
+      //final state is sigma0 p 
+      if(R > ((sigma[0] + sigma[1])/sigma_p)){
 
-  }
-  //lambda neutron
-  else if(hyp_state == 4){
+         //lambda + proton -> sigma0 + proton
 
-    //final state is sigmaM p 
-    if(R > ((sigma[3] + sigma[4])/sigma_n)){
+         ij = 1;
+
+         p[0].set_pdg_and_mass(PDG::pdg_Sigma,PDG::mass_Sigma);
+         p[1].set_pdg_and_mass(PDG::pdg_proton,PDG::mass_proton);
+
+      }
+      //final state is sigmaP n    
+      else if(R > (sigma[0]/sigma_p)){
+
+         //lambda + proton -> sigmaP + neutron
+
+         ij = 1;
+
+         p[0].set_pdg_and_mass(PDG::pdg_SigmaP,PDG::mass_SigmaP);
+         p[1].set_pdg_and_mass(PDG::pdg_neutron,PDG::mass_neutron);
+
+      }
+      //final state is lambda p
+      else {
+
+         //lambda + proton -> sigmaP + neutron
+
+         ij = 1;
+
+         p[0].set_pdg_and_mass(PDG::pdg_Lambda,PDG::mass_Lambda);
+         p[1].set_pdg_and_mass(PDG::pdg_proton,PDG::mass_proton);
+
+      }
+
+   }
+   //lambda neutron
+   else if(hyp_state == 4){
+
+      //final state is sigmaM p 
+      if(R > ((sigma[3] + sigma[4])/sigma_n)){
+
+         //lambda + neutron -> sigmaM + proton
+
+         ij = 2;
+
+         p[0].set_pdg_and_mass(PDG::pdg_SigmaM,PDG::mass_SigmaM);
+         p[1].set_pdg_and_mass(PDG::pdg_proton,PDG::mass_proton);
+      }
+      //final state is sigma0 n    
+      else if(R > (sigma[3]/sigma_n)){
+
+
+         //lambda + neutron -> sigma0 + neutron
+
+         ij = 0;
+
+         p[0].set_pdg_and_mass(PDG::pdg_Sigma,PDG::mass_Sigma);
+         p[1].set_pdg_and_mass(PDG::pdg_neutron,PDG::mass_neutron);
+
+      }
+      //final state is lambda n
+      else {
+
+         //lambda + neutron -> lambda + neutron
+
+         ij = 0;
+
+         p[0].set_pdg_and_mass(PDG::pdg_Lambda,PDG::mass_Lambda);
+         p[1].set_pdg_and_mass(PDG::pdg_neutron,PDG::mass_neutron);
+
+
+
+         //  std::cout << "Final state lambda neutron" << std::endl;
+         // std::cout << p[0].pdg << "  " << p[1].pdg << std::endl;
+
+      }
+   }
+
+   //sigma 0 proton
+   else  if(hyp_state == 1){
+
+
+      //final state is sigmaP neutron 
+      if(R > ((sigma[0] + sigma[1])/sigma_p)){
+
+         ij=1;
+
+         p[0].set_pdg_and_mass(PDG::pdg_SigmaP,PDG::mass_SigmaP);
+         p[1].set_pdg_and_mass(PDG::pdg_neutron,PDG::mass_neutron);
+      }
+      //final state is Lambda proton    
+      else if(R > (sigma[0]/sigma_p)){
+
+         ij=1;
+
+         p[0].set_pdg_and_mass(PDG::pdg_Lambda,PDG::mass_Lambda);
+         p[1].set_pdg_and_mass(PDG::pdg_proton,PDG::mass_proton);
+
+
+      }
+      //final state is sigma 0 proton
+      else {
+
+         ij=1;
+
+         p[0].set_pdg_and_mass(PDG::pdg_Sigma,PDG::mass_Sigma);
+         p[1].set_pdg_and_mass(PDG::pdg_proton,PDG::mass_proton);
+
+      }
+   }
+
+   //initial state is sigma0 neutron
+   else  if(hyp_state == 5){
+
+      //final state is sigmaM p 
+      if(R > ((sigma[3] + sigma[4])/sigma_n)){
+
+         ij=2;
+
+         p[0].set_pdg_and_mass(PDG::pdg_SigmaM,PDG::mass_SigmaM);
+         p[1].set_pdg_and_mass(PDG::pdg_proton,PDG::mass_proton);
+      }
+      //final state is Lambda n    
+      else if(R > (sigma[3]/sigma_n)){
+
+         ij=0;
+
+         p[0].set_pdg_and_mass(PDG::pdg_Lambda,PDG::mass_Lambda);
+         p[1].set_pdg_and_mass(PDG::pdg_neutron,PDG::mass_neutron);
+
+         // std::cout << "initial state sigma0 neutron" << std::endl;
+
+      }
+      //final state is Sigma0 neutron
+      else {
+
+         ij=0;
+
+         p[0].set_pdg_and_mass(PDG::pdg_Sigma,PDG::mass_Sigma);
+         p[1].set_pdg_and_mass(PDG::pdg_neutron,PDG::mass_neutron);
+
+      }
+   }
+
+
+   //sigmaM proton
+   else if(hyp_state == 2){
 
       ij=2;
 
-      p[0].set_pdg_and_mass(PDG::pdg_SigmaM,PDG::mass_SigmaM);
-      p[1].set_pdg_and_mass(PDG::pdg_proton,PDG::mass_proton);
-    }
-    //final state is sigma0 n    
-    else if(R > (sigma[3]/sigma_n)){
+      //final state is sigma0 neutron 
+      if(R > ((sigma[0] + sigma[1])/sigma_p)){
 
-      ij=0;
+         p[0].set_pdg_and_mass(PDG::pdg_Sigma,PDG::mass_Sigma);
+         p[1].set_pdg_and_mass(PDG::pdg_neutron,PDG::mass_neutron);
+      }
+      //final state is Lambda neutron    
+      else if(R > (sigma[0]/sigma_p)){
 
-      p[0].set_pdg_and_mass(PDG::pdg_Sigma,PDG::mass_Sigma);
-      p[1].set_pdg_and_mass(PDG::pdg_neutron,PDG::mass_neutron);
+         p[0].set_pdg_and_mass(PDG::pdg_Lambda,PDG::mass_Lambda);
+         p[1].set_pdg_and_mass(PDG::pdg_neutron,PDG::mass_neutron);
 
-    }
-    //final state is lambda n
-    else {
+         //  std::cout << "initial state sigmaM proton" << std::endl;
 
-      ij=0;
+      }
+      //final state is sigma M  proton
+      else {
 
-      //  std::cout << "lambda n -> lambda n" << std::endl;
+         p[0].set_pdg_and_mass(PDG::pdg_SigmaM,PDG::mass_SigmaM);
+         p[1].set_pdg_and_mass(PDG::pdg_proton,PDG::mass_proton);
 
-      p[0].set_pdg_and_mass(PDG::pdg_Lambda,PDG::mass_Lambda);
-      p[1].set_pdg_and_mass(PDG::pdg_neutron,PDG::mass_neutron);
+      }
+   }
 
+   //initial state is sigmaM neutron
+   else  if(hyp_state == 6){
 
+      ij = 1;
 
-      //  std::cout << "Final state lambda neutron" << std::endl;
-      // std::cout << p[0].pdg << "  " << p[1].pdg << std::endl;
-
-    }
-  }
-
-  //sigma 0 proton
-else  if(hyp_state == 1){
-
-
-    //final state is sigmaP neutron 
-    if(R > ((sigma[0] + sigma[1])/sigma_p)){
-
-      ij=1;
-
-      p[0].set_pdg_and_mass(PDG::pdg_SigmaP,PDG::mass_SigmaP);
-      p[1].set_pdg_and_mass(PDG::pdg_neutron,PDG::mass_neutron);
-    }
-    //final state is Lambda proton    
-    else if(R > (sigma[0]/sigma_p)){
-
-      ij=1;
-
-      p[0].set_pdg_and_mass(PDG::pdg_Lambda,PDG::mass_Lambda);
-      p[1].set_pdg_and_mass(PDG::pdg_proton,PDG::mass_proton);
-
-
-    }
-    //final state is sigma 0 proton
-    else {
-
-      ij=1;
-
-      p[0].set_pdg_and_mass(PDG::pdg_Sigma,PDG::mass_Sigma);
-      p[1].set_pdg_and_mass(PDG::pdg_proton,PDG::mass_proton);
-
-    }
-  }
-
-  //initial state is sigma0 neutron
- else  if(hyp_state == 5){
-
-    //final state is sigmaM p 
-    if(R > ((sigma[3] + sigma[4])/sigma_n)){
-
-      ij=2;
-
-      p[0].set_pdg_and_mass(PDG::pdg_SigmaM,PDG::mass_SigmaM);
-      p[1].set_pdg_and_mass(PDG::pdg_proton,PDG::mass_proton);
-    }
-    //final state is Lambda n    
-    else if(R > (sigma[3]/sigma_n)){
-
-      ij=0;
-
-      p[0].set_pdg_and_mass(PDG::pdg_Lambda,PDG::mass_Lambda);
-      p[1].set_pdg_and_mass(PDG::pdg_neutron,PDG::mass_neutron);
-
-      // std::cout << "initial state sigma0 neutron" << std::endl;
-
-    }
-    //final state is Sigma0 neutron
-    else {
-
-      ij=0;
-
-      p[0].set_pdg_and_mass(PDG::pdg_Sigma,PDG::mass_Sigma);
-      p[1].set_pdg_and_mass(PDG::pdg_neutron,PDG::mass_neutron);
-
-    }
-  }
-
-
- //sigmaM proton
- else if(hyp_state == 2){
-
-   ij=2;
-
-    //final state is sigma0 neutron 
-    if(R > ((sigma[0] + sigma[1])/sigma_p)){
-
-      p[0].set_pdg_and_mass(PDG::pdg_Sigma,PDG::mass_Sigma);
-      p[1].set_pdg_and_mass(PDG::pdg_neutron,PDG::mass_neutron);
-    }
-    //final state is Lambda neutron    
-    else if(R > (sigma[0]/sigma_p)){
-
-      p[0].set_pdg_and_mass(PDG::pdg_Lambda,PDG::mass_Lambda);
-      p[1].set_pdg_and_mass(PDG::pdg_neutron,PDG::mass_neutron);
-
-      //  std::cout << "initial state sigmaM proton" << std::endl;
-
-    }
-    //final state is sigma M  proton
-    else {
-
-      p[0].set_pdg_and_mass(PDG::pdg_SigmaM,PDG::mass_SigmaM);
-      p[1].set_pdg_and_mass(PDG::pdg_proton,PDG::mass_proton);
-
-    }
-  }
-
-  //initial state is sigmaM neutron
- else  if(hyp_state == 6){
-
-    ij = 1;
-
-    //only one final state allowed
+      //only one final state allowed
 
       p[0].set_pdg_and_mass(PDG::pdg_SigmaM,PDG::mass_SigmaM);
       p[1].set_pdg_and_mass(PDG::pdg_neutron,PDG::mass_neutron);
 
- }
+   }
 
 
- //sigmaP proton
-  else if(hyp_state == 3){
+   //sigmaP proton
+   else if(hyp_state == 3){
 
-    ij=0;
+      ij=0;
 
-    //only one allowed final state
+      //only one allowed final state
 
       p[0].set_pdg_and_mass(PDG::pdg_SigmaP,PDG::mass_SigmaP);
       p[1].set_pdg_and_mass(PDG::pdg_proton,PDG::mass_proton);
 
 
-  }
+   }
 
 
-  //initial state is sigmaP neutron
-  else if(hyp_state == 7){
+   //initial state is sigmaP neutron
+   else if(hyp_state == 7){
 
-    ij=1;
+      ij=1;
 
-    //final state is Lambda p   
-    if(R > (sigma[3]/sigma_n)){
+      //final state is Lambda p   
+      if(R > (sigma[3]/sigma_n)){
 
-      p[0].set_pdg_and_mass(PDG::pdg_Lambda,PDG::mass_Lambda);
-      p[1].set_pdg_and_mass(PDG::pdg_proton,PDG::mass_proton);
+         p[0].set_pdg_and_mass(PDG::pdg_Lambda,PDG::mass_Lambda);
+         p[1].set_pdg_and_mass(PDG::pdg_proton,PDG::mass_proton);
 
-      //   std::cout << "initial state sigmaP neutron" << std::endl;
+         //   std::cout << "initial state sigmaP neutron" << std::endl;
 
-    }
-    //final state is SigmaP neutron
-    else {
+      }
+      //final state is SigmaP neutron
+      else {
 
-      p[0].set_pdg_and_mass(PDG::pdg_SigmaP,PDG::mass_SigmaP);
-      p[1].set_pdg_and_mass(PDG::pdg_neutron,PDG::mass_neutron);
+         p[0].set_pdg_and_mass(PDG::pdg_SigmaP,PDG::mass_SigmaP);
+         p[1].set_pdg_and_mass(PDG::pdg_neutron,PDG::mass_neutron);
 
-    }
-  }
-  else 
-    { 
+      }
+   }
+   else 
+   { 
 
       ij=3; 
 
 
-    }
+   }
 
 }
 
 /////////////////////////////////////////////////////////////////////////////////////
 /* Hyperon Phase space corrections
- 
-
-Added by C Thorpe Nov 2019
-
-Calculate momenta of outgoing particles for two different final (2 particle) states
-in the CMS and take their ratio
 
 
-compare the reactions:
+   Added by C Thorpe Nov 2019
 
-rs -> 1a+2a 
-rs -> 1b+2b
+   Calculate momenta of outgoing particles for two different final (2 particle) states
+   in the CMS and take their ratio
 
-Argument list:
-rs = cms energy
-M1a = Mass of particle 1a
-M2a = Mass of particle 2a
-M1b = Mass of paritcle 1b
-M2b = Mass of particle 2b
+
+   compare the reactions:
+
+   rs -> 1a+2a 
+   rs -> 1b+2b
+
+   Argument list:
+   rs = cms energy
+   M1a = Mass of particle 1a
+   M2a = Mass of particle 2a
+   M1b = Mass of paritcle 1b
+   M2b = Mass of particle 2b
 
 */
 
 //////////////////////////////////////////////////////////////////////////////////////
-  
+
 double phase_space(double rs, double M1a, double M2a, double M1b, double M2b){
 
-    double a = cms_momentum2(rs*rs,M1a*M1a,M2a*M2a);
-  double b = cms_momentum2(rs*rs,M1b*M1b,M2b*M2b);
+   double a = cms_momentum2(rs*rs,M1a*M1a,M2a*M2a);
+   double b = cms_momentum2(rs*rs,M1b*M1b,M2b*M2b);
 
-//if either process is forbidden
-if(a < 0 || b < 0) return 0;
+   // If either process is forbidden
+   if(a < 0 || b < 0) return 0;
 
-  //a =  pow(rs,4) + pow(M1a,4) + pow(M2a,4) - 2*(rs*rs*M1a*M1a + rs*rs*M2a*M2a + M1a*M1a*M2a*M2a);
-  //b = pow(rs,4) + pow(M1b,4) + pow(M2b,4) - 2*(rs*rs*M1b*M1b + rs*rs*M2b*M2b + M1b*M1b*M2b*M2b);
- 
-    return sqrt(a/b);
+   //a =  pow(rs,4) + pow(M1a,4) + pow(M2a,4) - 2*(rs*rs*M1a*M1a + rs*rs*M2a*M2a + M1a*M1a*M2a*M2a);
+   //b = pow(rs,4) + pow(M1b,4) + pow(M2b,4) - 2*(rs*rs*M1b*M1b + rs*rs*M2b*M2b + M1b*M1b*M2b*M2b);
+
+   return sqrt(a/b);
 
 }
 
 /////////////////////////////////////////////////////////////////////////////////////////
 
 /*
-
-Compute CMS energy of an initial state given the momentum of the hyperon in the nucleon rest frame
-and the masses of the hyperon and nucleon
-
+   Compute CMS energy of an initial state given the momentum of the hyperon in the nucleon rest frame
+   and the masses of the hyperon and nucleon
 */
 
 double cms_energy(double Plab, double M_N, double M_Y){
 
-  return sqrt(M_N*M_N + M_Y*M_Y + 2*M_N*sqrt(M_Y*M_Y+Plab*Plab));
+   return sqrt(M_N*M_N + M_Y*M_Y + 2*M_N*sqrt(M_Y*M_Y+Plab*Plab));
 
 }
 
+/////////////////////////////////////////////////////////////////////////////////////////

--- a/src/hyperon_interaction.cc
+++ b/src/hyperon_interaction.cc
@@ -26,7 +26,9 @@ p2 = hyperon 4 momentum
 
  */
 
-//DO NOT USE
+
+// Deprecated
+/*
 double Hyperon_Interaction(double Q2, double E_nu, int h, vect k1, vect p1, vect k2, vect p2,bool anti){
 
   //assume input particles are on shell
@@ -87,17 +89,6 @@ double Hyperon_Interaction(double Q2, double E_nu, int h, vect k1, vect p1, vect
   p1p2 = p1*p2;
   k1k2 = k1*k2;
 
-  /*  
-    std::cout << "Q2: " << Q2 << std::endl;
-    std::cout << "p1k1: " <<  p1k1 << std::endl;
-    std::cout << "p2k2: " << p2k2 << std::endl;
-    std::cout << "p1k2: " << p1k2 << std::endl;
-    std::cout << "p2k1: " << p2k1 << std::endl;
-    std::cout <<"p1p2: " << p1p2 << std::endl;
-    std::cout <<"k1k2: " << k1k2 << std::endl;
-    std::cout << std::endl;
-  */ 
-
   p1q = p1k1 - p1k2;
   p2q = p2k1 - p2k2;
   k1q = p2k1 - p1k1;
@@ -126,20 +117,6 @@ double Hyperon_Interaction(double Q2, double E_nu, int h, vect k1, vect p1, vect
   p2mp2n = 16*p2k1*p2k2 - 8*My*My*k1k2;
 
 
-  /*
-    std::cout << "Q2: " << Q2 << std::endl;
-    std::cout << "p1mp2n: " <<  p1mp2n << std::endl;
-    std::cout << "p2mp1n: " << p2mp1n << std::endl;
-    std::cout << "qmqn: " << qmqn << std::endl;
-    std::cout << "p1mqn: " << p1mqn << std::endl;
-    std::cout <<"p2mqn: " << p2mqn << std::endl;
-    std::cout <<"qmp1n: " << qmp1n << std::endl;
-    std::cout <<"qmp2n: " << qmp2n << std::endl;
-   std::cout <<"gmn: " << gmn << std::endl;
-    std::cout << std::endl;
-    std::cout << std::endl;
-  */
-
   // h+11 = 12,13,14 for the hyperon channels
 
   //calculate form factors
@@ -149,14 +126,6 @@ double Hyperon_Interaction(double Q2, double E_nu, int h, vect k1, vect p1, vect
   //SCC form factors
   //real and imaginary parts of g2 (axial SCC)
   list(Rg2,Ig2) = g2(q2,h+11);
-
-  /*
-   std::cout << std::endl;
-   std::cout << f1 << std::endl;
-   std::cout << f2 << std::endl;
-  std::cout << g1 << std::endl;
-  std::cout << g3 << std::endl;
-  */
 
   //list of all of the variables needed by H tensor  
 
@@ -210,33 +179,20 @@ double Hyperon_Interaction(double Q2, double E_nu, int h, vect k1, vect p1, vect
    + H.MG2G2()*(Rg2*Rg2+Ig2*Ig2)/(M*M) + H.F1RG2()*f1*Rg2/M 
    + H.F2RG2()*f2*Rg2/(M*M) + H.G1RG2()*g1*Rg2/M +2*H.RG2G3()*Rg2*g3/(M*M);
  
- 
-  /*
- Mat = 64*f1*f1*(p2k1*p1k2 + p1k1*p2k2 - Mp*My*k1k2)
-
-+  64*g1*g1*(p2k1*p1k2 + p1k1*p2k2 + Mp*My*k1k2) 
-
- - 128*f1*g1*(p1k1*p2k2 - p1k2*p2k1)
-
-+ (32*f2*f2/(M*M))*(-2*Mp*My*k1q*k2q - Mp*My*q2*k1k2 - 2*k1q*k2q*p1p2
-+ 2*p2k1*k2q*p1q + 2*p1k1*k2q*p2q + 2*k1q*p2k2*p1q + 2*k1q*p1k2*p2q
-			- 2*q2*p2k1*p1k2 - 2*q2*p1k1*p2k2 + q2*p1p2*k1k2)
-
-   + (64*f1*f2/M)*(-Mp*k1q*p2k2 - Mp*p2k1*k2q - Mp*k1k2*p2q 
-		   + My*k1q*p1k2 + My*p1k1*k2q + My*k1k2*p1q)
- 
- - (128*f2*g1/M)*(Mp*(p2k1*k2q - k1q*p2k2) + My*(p1k1*k2q - k1q*p1k2));
-  */
- 
-
+  
  //if(Mat < 0){std::cout << Mat << std::endl; std::cin.get();}
  
   return Mat/32;
 }
 
-//implementation of Aligarh MU Model from https://arxiv.org/pdf/1806.08597.pdf
+*/
 
+// DEPRECATED
+
+//implementation of Aligarh MU Model from https://arxiv.org/pdf/1806.08597.pdf
+/*
 double Singh_Model(double Q2, double E_nu, int h, vect k1, vect p1, vect k2, vect p2,bool anti){
+
 
  //assume input particles are on shell
   //set Hyperon mass
@@ -268,6 +224,7 @@ double Singh_Model(double Q2, double E_nu, int h, vect k1, vect p1, vect k2, vec
   double t = (k1-k2)*(k1-k2);
   double ml = sqrt(k2*k2);
   double Delta = My - Mp;
+
 
   //also have M = Mp+My
 
@@ -330,4 +287,98 @@ Mat =  f1*f1*0.5*(2*(Mp*Mp -s)*(My*My-s) - t*(Delta*Delta-2*s) + t*t + ml*ml*(De
 
   return Mat;
 
+
 }
+*/
+
+
+double Singh_Model2(double Q2, double E_nu, int h, double Mp, double My ,double ml , bool anti){
+
+  double q2 = -Q2; //q^2 = -Q^2
+
+  double Mat; //Contraction of hadronic and leptonic tensors
+
+  //form factors
+  double f1,f2,f3,f4,g1,Rg2,Ig2,g3;
+
+
+  // s and t are Mandelstam variables
+
+  double s=(E_nu+Mp)*(E_nu+Mp)-E_nu*E_nu;
+
+
+
+  //  double s = (p1+k1)*(p1+k1);
+  double t = q2;
+  //  double ml = sqrt(k2*k2);
+  double Delta = My - Mp;
+  double M = Mp + My; 
+ 
+
+  // h+11 = 12,13,14 for the hyperon channels
+ 
+  //calculate form factors
+  list(f1,f2)=f12(q2,h+11);
+  list(g1,g3) = fap(q2,h+11);
+
+  //SCC form factors
+  //real and imaginary parts of g2 (axial SCC)
+  list(Rg2,Ig2) = g2(q2,h+11);
+
+  //note sign convention for axial ffs in NuWro is different to Aligarh paper
+
+  //if antineutrino flip signs of vector/axial interference terms
+  if(anti == true)
+    {
+      g1 *= (-1);
+      g3 *= (-1); 
+      Rg2 *= (-1);
+      Ig2 *= (-1); 
+    }
+
+
+  Mat =  f1*f1*0.5*(2*(Mp*Mp -s)*(My*My-s) - t*(Delta*Delta-2*s) + t*t + ml*ml*(Delta*Delta - 2*s -t))
+
+     +  g1*g1*0.5*(2*(Mp*Mp -s)*(My*My-s) - t*(M*M-2*s) + t*t + ml*ml*(M*M - 2*s -t))
+
+     + (f2*f2/(M*M))*0.25*(-2*t*(Mp*Mp*Mp*Mp-2*s*(Mp*Mp+My*My) + My*My*My*My+2*s*s) + 2*t*t*(M*M-2*s)
+           + ml*ml*(2*Delta*M*(Mp*Mp+My*My-2*s)+t*((Mp-3*My)*(Mp+My)+4*s)+t*t)
+           -ml*ml*ml*ml*((3*Mp-My)*M+t))
+
+     + g1*f1*(-1)*(t*(Mp*Mp+My*My - 2*s - t)+ml*ml*(Mp*Mp-My*My+t))
+
+     + (f1*f2/M)*(-1)*(t*M*(Delta*Delta-t) + ml*ml*( (-1)*Delta*(My*My-s)+My*t) +ml*ml*ml*ml*Mp)
+
+     + (f2*g1/M)*(-M)*(t*(Mp*Mp+My*My-2*s-t)+ml*ml*(Mp*Mp-My*My+t)) 
+
+     + (g3*g3/(M*M))*ml*ml*(ml*ml-t)*(Delta*Delta -t)
+
+     + (g1*g3/M)*(-2)*(ml*ml)*(ml*ml*Mp + Mp*Mp*Mp - Mp*Mp*My - Mp*(s+t) + My*s)
+
+     //second class current
+
+     + ((Rg2*Rg2+Ig2*Ig2)/(M*M))*(0.25*(4*(Delta*Delta - t)*((Mp*Mp-s)*(My*My-s)+s*t) + ml*ml*(4*Delta*(Mp*Mp*Mp+Mp*Mp*My - Mp*(3*s+t)+My*s) + 2*Delta*Delta*(M*M - 2*s - t) - (4*s+t)*(Delta*Delta -t))  + 2*Delta*Delta*(-2*(Mp*Mp-s)*(My*My-s)-t*(M*M +2*s)+t*t) + ml*ml*ml*ml*(Delta*Delta + 4*Mp*Delta - t)))
+
+     + (Rg2*f1/M)*(-Delta*(t*(Mp*Mp + My*My - 2*s-t) + ml*ml*(Mp*Mp - My*My + t)))
+
+     + (Rg2*f2/(M*M))*(Delta*(-M)*(t*(Mp*Mp + My*My - 2*s-t)+ml*ml*(Mp*Mp-My*My+t)))
+
+     + (Rg2*g1/M)*((Delta*(-t*(M*M)+t*t) + ml*ml*(Mp*Mp*Mp + Mp*Mp*My + Delta*(M*M - 2*s - t ) - 3*Mp*s - M*t + My*s) + ml*ml*ml*ml*Mp))
+
+     + (Rg2*g3/(M*M))*(ml*ml*(-2*Delta*(ml*ml*Mp + Mp*Mp*Mp - Mp*Mp*My - Mp*(s+t) + My*s) - (Delta*Delta-t)*(ml*ml + 2*Mp*Mp - 2*s -t)));
+
+
+  //if sqaured matrix element is negative there is a problem!						 
+  //if(Mat < 0){std::cout << Q2 << "  "  << Mat << std::endl; std::cin.get();}
+
+
+  return Mat;
+
+}
+
+
+
+
+
+
+

--- a/src/hyperon_interaction.h
+++ b/src/hyperon_interaction.h
@@ -3,8 +3,10 @@
 #ifndef _hyperon_interaction_h_
 #define _hyperon_interaction_h_
 
-double Hyperon_Interaction(double Q2, double E_nu, int h, vect k1, vect p1, vect k2, vect p2,bool anti);
+// DEPRECATED
+//double Hyperon_Interaction(double Q2, double E_nu, int h, vect k1, vect p1, vect k2, vect p2,bool anti);
+//double Singh_Model(double Q2, double E_nu, int h , vect k1 , vect p1 , vect k2, vect p2,bool neu);
 
-double Singh_Model(double Q2, double E_nu, int h , vect k1 , vect p1 , vect k2, vect p2,bool neu);
+double Singh_Model2(double Q2, double E_nu, int h, double Mp, double My ,double ml , bool anti);
 
 #endif

--- a/src/kaskada7.cc
+++ b/src/kaskada7.cc
@@ -11,7 +11,8 @@ kaskada::kaskada(params &p, event &e1, input_data *input)
 
   if (par.nucleus_p + par.nucleus_n < 3)
     par.kaskada_w = 0;  //for free nucleons and deuteron there is no extra binding energy
-  
+ 
+ 
   e = &e1;
   max_step = par.step * fermi;    // set maximum step defined in params
   nucl = make_nucleus(par);       // create nucleus defined in params
@@ -32,7 +33,8 @@ kaskada::~kaskada()
 ////////////////////////////////////////
 
 int kaskada::kaskadaevent()
-{ 
+{
+ 
   int result = 0;
   
   if (e->weight <= 0)
@@ -65,13 +67,16 @@ int kaskada::kaskadaevent()
         
   while (parts.size () > 0 and nucl->Ar() > 0)  // main loop in cascade
   {           
+
+
     particle p1 = parts.front();                // point a particle from a queue
     parts.pop();                                // remove this particle from a temp vector
     p = &p1;
 
     X = prepare_interaction();                  // set the density and the total cross section
                                                 // calculate free path
-    
+   
+ 
     if (!move_particle()) continue;             // propagate particle, returns false if jailed
 
     if (X.r >= radius)                          // particle leaves nucleus
@@ -90,6 +95,7 @@ int kaskada::kaskadaevent()
 
   clean();  // if nucleus has evaporated the part queue may not be empty
 
+
   return result;
 }
 
@@ -102,22 +108,26 @@ void kaskada::prepare_particles()
   for (int i = 0; i < e->out.size(); i++)
   {
     particle p1 = e->out[i];
+	
                 
     if (nucleon_or_pion (p1.pdg)) // formation zone for both nucleons and pions
     {           
       if (nucleon (p1.pdg))
       { 
         p1.primary = true;
-        
+
+ 
         // add the binding energy substracted in the primary vertex
         // (for Global Fermi Gas Local Fermi Gas and Spectral Function)
         if (e->flag.qel and (par.sf_method != 0 or par.nucleus_target == 2))
           p1.set_energy (p1.E() + nucl->Ef(p1) + par.kaskada_w);
+
         else if (par.nucleus_target == 1 and (e->flag.qel or e->flag.res))
           p1.set_energy (p1.E() + par.nucleus_E_b);
-          
+
         p1.set_fermi(nucl->Ef(p1));
-      
+
+ 
         if (p1.Ek() <= par.kaskada_w + p1.his_fermi)  // jailed nucleon if its kinetic energy
                                                       // is lower than binding energy
         {
@@ -131,26 +141,19 @@ void kaskada::prepare_particles()
       
       double fz = formation_zone(p1, par, *e);        // calculate formation zone
       p1.krok(fz);      // move particle by a distance defined by its formation zone
+
       
       parts.push (p1);  // put particle to a queue
     }
-
-    //add C Thorpe 
-    //hyperon production
-    else if(hyperon (p1.pdg))
+    else if(hyperon (p1.pdg)) // if a hyperon
     {  
-    p1.set_fermi(nucl->hyp_BE(p1.r.length()));
 
-    //if hyperon energy less than BE it is jailed
-	  if(p1.Ek() < p1.his_fermi)
-	  {
-	    p1.endproc=jailed;
-	    if(par.kaskada_writeall) 
-              e->all.push_back(p1);
-        continue;
-    }
+    // Add BE 
+    p1.set_fermi(nucl->hyp_BE(p1.r.length(),p1.pdg));
+    p1.set_energy(p1.E() + p1.his_fermi);
 
-    parts.push(p1); // add particle to queue
+     parts.push(p1); // add particle to queue
+
     }
     else              // if not a nucleon nor pion or hyperon
     {
@@ -162,8 +165,9 @@ void kaskada::prepare_particles()
     }
   }
   
-  for (int i = 0; i<15; i++)  // number of dynamics defined in proctable.h
-    e->nod[i] = 0;
+  for (int i = 0; i<18; i++)  // number of dynamics defined in proctable.h
+     e->nod[i] = 0;
+
   e->r_distance = 10;         // new JS ; default (large) value, if unchanged no absorption took place
 }
 
@@ -171,6 +175,7 @@ void kaskada::prepare_particles()
 
 interaction_parameters kaskada::prepare_interaction()
 {
+
   interaction_parameters res;
 
   res.pdg = p->pdg;
@@ -210,6 +215,7 @@ interaction_parameters kaskada::prepare_interaction()
 
   res.xsec = res.dens_n*res.xsec_n + res.dens_p*res.xsec_p; // calculate the inverse of the mean free path
 
+
   assert(res.xsec>=0);                      // make sure that the cross section is positive
 
   if (res.xsec != 0)
@@ -226,7 +232,8 @@ interaction_parameters kaskada::prepare_interaction()
 ////////////////////////////////////////
 
 bool kaskada::move_particle()
-{ 
+{
+ 
   p->krok (min (max_step, X.freepath));   // propagate by no more than max_step
 
   if (!(p->nucleon() || hyperon(p->pdg))) // pion can not be jailed
@@ -249,7 +256,7 @@ bool kaskada::move_particle()
 
   if(hyperon(p->pdg))
   {
-    //if hyperon KE falls below its potential energy -  hyperon is jailed
+    // If hyperon KE falls below its potential energy -  hyperon is jailed
     if(p->Ek() < p->his_fermi)
     {
       p->endproc=jailed;
@@ -264,7 +271,8 @@ bool kaskada::move_particle()
 ////////////////////////////////////////
 
 bool kaskada::leave_nucleus()
-{ 
+{
+ 
   if (nucleon (p->pdg))                 // substract fermi energy and work function
   {
     // jail nucleon if its kinetic energy is lower than binding energy
@@ -277,23 +285,27 @@ bool kaskada::leave_nucleus()
       return false;                     // particle did not escape
     }
     else
+	
       p->set_energy(p->E() - p->his_fermi - par.kaskada_w);
   }
   else if(hyperon(p->pdg))
   {
-    //adjust hyperon for remaining binding energy
+    // Adjust hyperon for remaining binding energy, jail if it cannot escape
     if (p->Ek() <  p->his_fermi)
     {
       p->endproc=jailed;
- 
-      //perhaps add hyperon to nucleus here
+      //TODO: Perhaps add hyperon to nucleus here (or decay it)
       if(par.kaskada_writeall) e->all.push_back(*p);
       return false;
     }
-    // subtract binding energy from hyperon energy and set momentum so it is on shell
-	  p->set_energy(p->E() -  p->his_fermi);
+    // Subtract binding energy from hyperon energy and set momentum so it is on shell
+    else {
+	    p->set_energy(p->E() -  p->his_fermi);
+    }
+
+
   }
-    
+
   p->endproc=escape;
   e->post.push_back (*p);
   
@@ -307,11 +319,12 @@ bool kaskada::leave_nucleus()
 
 bool kaskada::make_interaction()
 {
+
   int loop = 0;
   static int call=0;
   static int rep=0;
   static int procid=0;
-      
+  
   while(++call && 0 == I->particle_scattering (*p, *nucl, X)) // try to generate kinematics
   {
     if(loop==0)
@@ -344,8 +357,27 @@ bool kaskada::make_interaction()
       return false;
     }
 
-  if ((p->pdg == 2112 or p->pdg == 2212) and nucl->pauli_blocking (X.p, X.n)) // check if there was Pauli blocking
-    return false;
+	//TODO check this
+	if(nucl->pauli_blocking (X.p, X.n)) return false;
+	
+        // C Thorpe: Check if hyperon can be moved to new value of potential.
+        // Ignore interaction if it can't
+
+        if( (PDG::Lambda(p->pdg) && PDG::Sigma(X.p[0].pdg)) || (PDG::Sigma(p->pdg) && PDG::Lambda(X.p[0].pdg)) ){
+
+           double V_old = p->his_fermi;
+           double V_new = nucl->hyp_BE(p->r.length(),X.p[0].pdg);
+
+
+           // Check if hyperon may be moved to new value of potential
+           if(X.p[0].Ek() < V_old - V_new) return false;
+
+           X.p[0].set_fermi(V_new);
+           X.p[0].set_energy(X.p[0].E() - V_old + V_new);
+
+        }
+        else if(PDG::hyperon(X.p[0].pdg)) X.p[0].set_fermi(p->his_fermi);
+
 
   //JTS - removed assertion below 
   //assert(check(*p,X.p2,nucl->spectator,X.n,X.p,I->process_id()));
@@ -358,24 +390,29 @@ bool kaskada::make_interaction()
 
 bool kaskada::finalize_interaction()
 {
+
   p->endproc=I->process_id();
+
   
   double FE = nucl->Ef(X.p2);
-  
+ 
   if (!p->nucleon())
   {
-    for (int i = 0; i < X.n; i++)
+    for (int i = 0; i < X.n; i++){
       if (nucleon(X.p[i].pdg))
       {
         X.p[i].set_fermi (FE);
         break;
       }
+	
+    }
+
   }
   else
   {
     double he = (p->his_fermi > FE) ? p->his_fermi : FE;
     double le = p->his_fermi + FE - he;
-    
+
     int n_he = -1;
     int n_le = -1;
     
@@ -395,6 +432,8 @@ bool kaskada::finalize_interaction()
     X.p[n_he].set_fermi (he);
     X.p[n_le].set_fermi (le);
   }
+
+
   
   for (int i = 0; i < X.n; i++)
   {
@@ -410,18 +449,37 @@ bool kaskada::finalize_interaction()
         e->all.push_back(X.p[i]);
       continue;
     }
+	//hyperon
+    else if( hyperon(p->pdg) && hyperon(X.p[i].pdg) ){
+
+		if(X.p[i].Ek() < X.p[i].his_fermi){
+			X.p[i].endproc=jailed;
+			if(par.kaskada_writeall) 
+			e->all.push_back(X.p[i]);
+			continue;
+		}
+
+	}
+
+        // Add particle back to queue if not jailed
+	parts.push(X.p[i]);
+
+/*
     else
     {
+	
       parts.push (X.p[i]);
       //double fz = formation_zone(X.p[i], par);
       //X.p[i].krok(fz);
     }
+*/
 
     //procinfo(*p,X.p2,X.n,X.p);
     
     if(par.kaskada_writeall)
       e->all.push_back (*p);
-  }
+
+  }//loop over p[i]
   
   int k = kod(I->process_id());
   e->nod[k]++;

--- a/src/kinematics.cc
+++ b/src/kinematics.cc
@@ -31,9 +31,12 @@ double bodek_kinematics(double Eb,particle nu,particle N0, particle &lepton, par
 //////////////////////////////////////////////////////////////////////////////////////////
 {
   static double M12=0.5*(PDG::mass_proton+PDG::mass_neutron);
-  double Ma = 56 * M12;	// Argon nucleus mass 
-  double Ma1 = Ma - M12 + Eb;  // mass of the spectator nucleus
+  double Ma = 56 * M12;	// Argon nucleus mass  
+ double Ma1 = Ma - M12 + Eb;  // mass of the spectator nucleus
   N0.t = 56 * M12 - sqrt ( Ma1*Ma1 + N0.momentum2 () );
+
+
+ 
   //if(N0*N0<0) return 0;
   double q2 = scatter_2 (nu, N0, lepton, N1);
   jakobian=jakob(nu,N0,lepton);
@@ -41,17 +44,49 @@ double bodek_kinematics(double Eb,particle nu,particle N0, particle &lepton, par
   return q2;
 }
 
+
+
+///////////////////////////////////////////////////////////
+double CT_bodek_kinematics(particle N0, int Z, int N){
+
+   // Composite model, check if nucleon is below fermi level
+
+   double kF = 220; // Fermi momentum
+
+   double Ma = Z*PDG::mass_proton + N*PDG::mass_neutron;
+   double Ma1 = Ma - N0.mass();
+   double Md = PDG::mass_proton + PDG::mass_neutron; // Deuteron mass
+
+   // If below fermi level
+   if(N0.momentum()<kF){
+      N0.t = Ma - sqrt(Ma1*Ma1 + N0.momentum2());
+   }
+   // Above fermi level
+   else {
+      N0.t = Md - sqrt(N0.mass2() + N0.momentum2());
+   }
+
+   return 0;
+}
+///////////////////////////////////////////////////////////
+
+
 //////////////////////////////////////////////////////////////////////////////////////////
-double bodek_binding_energy(particle N0, int A)
+double bodek_binding_energy(particle N0, int Z, int N)
 //////////////////////////////////////////////////////////////////////////////////////////
 {
-  static double M12=0.5*(PDG::mass_proton+PDG::mass_neutron);
-  double Ma  = A * M12;
-  double Ma1 = (A-1) * M12;
 
-  double Eb = sqrt(Ma1*Ma1 + N0.momentum2()) - Ma + sqrt(M12*M12 + N0.momentum2());
+   static double M12=0.5*(PDG::mass_proton+PDG::mass_neutron);
+   double Ma  = Z*PDG::mass_proton + N*PDG::mass_neutron;
+   double Ma1 = Ma - N0.mass();
+   double Md = PDG::mass_proton + PDG::mass_neutron; //deuteron mass
 
-  return Eb;
+   double p = N0.momentum();
+   double KE = sqrt(N0.mass2()+p*p) - N0.mass();
+
+   double Eb = sqrt(Ma1*Ma1 + N0.momentum2()) - Ma + sqrt(N0.mass2() + N0.momentum2());
+
+   return Eb;
 }
 
 

--- a/src/kinematics.h
+++ b/src/kinematics.h
@@ -7,7 +7,9 @@ double jakob(vect nu,vect N0,vect lepton);
 
 double bodek_kinematics(double Eb,particle nu,particle N0, particle &lepton, particle &N1,double & jakobian);
 
-double bodek_binding_energy(particle N0, int A);
+double CT_bodek_kinematics(particle N0, int Z, int N);
+
+double bodek_binding_energy(particle N0, int Z, int N);
 
 double czarek_kinematics(double Eb,particle nu,particle N0, particle &lepton, particle &N1,double &jakobian);
 

--- a/src/nucleus.cc
+++ b/src/nucleus.cc
@@ -43,7 +43,8 @@ nucleus::nucleus(params &par):
 		_kf=par.nucleus_kf;
 	}
 	//set hyperon binding energy
-	Y_Eb = par.hyp_Eb;
+	Lambda_Eb = par.hyp_Lambda_Eb;
+	Sigma_Eb = par.hyp_Sigma_Eb;
 }
 
 double nucleus::density (double r)
@@ -163,6 +164,7 @@ double nucleus :: Ef (particle &pa)
 		case 2: kmom = localkf (pa); break;
 		default: kmom = kF(); break;
 	};
+
 	
 	return sqrt(kmom*kmom + M*M) - M;
 }

--- a/src/nucleus.h
+++ b/src/nucleus.h
@@ -46,8 +46,9 @@ class nucleus
 						  /// 4 - spectral function (for carbon and oxygen, else lFG); 
 						  /// 5 - deuterium (forced for H2); 
 						  /// 6 - proton in deuterium (for tests only);
-	//hyperon potential at r=0
-	double Y_Eb;
+	// Hyperon potential at r=0
+	double Lambda_Eb;
+	double Sigma_Eb;
 		 
 	public:
 
@@ -81,7 +82,7 @@ class nucleus
 	bool pauli_blocking (particle p[], int n); ///< true if any of p[0]..p[n-1] is blocked (used in cascade)
 	bool pauli_blocking_old (particle &pa, double p0); ///< TRUE = PARTICLE IS BLOCKED (p0 - momentum of initial nucleon)
 
-	double hyp_BE(double r);
+	double hyp_BE(double r,int pdg);
 };
 
 ////////////////////////////////////////////////////////////////////////
@@ -92,6 +93,7 @@ class nucleus
 inline double nucleus::Ef()
 {
 	double const M=0.5*(PDG::mass_proton+PDG::mass_neutron);
+
 	return sqrt(_kf*_kf+M*M)-M;
 }
 
@@ -233,9 +235,25 @@ inline double nucleus::V(particle &p)
 	return (sqrt(p.mass2() + lkf*lkf) - p.mass());// + 7*MeV);// + 5*MeV;
 }
 
-inline double nucleus::hyp_BE(double r)
+
+///////////////////////////////////////////////////////////////////////////////
+/// potential of a hyperon
+///////////////////////////////////////////////////////////////////////////////
+
+inline double nucleus::hyp_BE(double r,int pdg)
 {
-  return Y_Eb*density(r)/density(0);
+
+
+switch(pdg){
+case 3122: return Lambda_Eb*density(r)/density(0);
+case 3212: case 3112: case 3222: return Sigma_Eb*density(r)/density(0);
+default: std::cout << "This is not a hyperon! Returning 0 for hyperon potential" << std::endl; return 0;
+}
+
+std::cout << "Should never reach here!" << std::endl;
+return 0;
+
+//  return Lambda_Eb*density(r)/density(0);
 }
 
 #endif

--- a/src/nuwro.cc
+++ b/src/nuwro.cc
@@ -318,7 +318,7 @@ void NuWro::makeevent(event* e, params &p)
 			e->flag.dis=e->flag.cc=true;
 			if (p.dyn_dis_cc) // dis cc
 			{
-				disevent (p, *e, true);
+				disevent (p, *e, *_nucleus, true);
 				if (p.pauli_blocking)
 					mypauli_spp (*e, *_nucleus);
 			}
@@ -327,7 +327,7 @@ void NuWro::makeevent(event* e, params &p)
 			e->flag.dis=e->flag.nc=true;
 			if (p.dyn_dis_nc) //dis nc
 			{
-				disevent (p, *e, false);
+				disevent (p, *e, *_nucleus, false);
 				if (p.pauli_blocking)
 					mypauli_spp (*e, *_nucleus);
 			}
@@ -404,7 +404,7 @@ void NuWro::makeevent(event* e, params &p)
 			break;
 		case 10:
 			e->flag.hyp=e->flag.cc=true;
-			if(p.dyn_hyp_cc) // qel hiperon lambda
+			if(p.dyn_hyp_cc) // qel hyperon
 			{
 				hypevent (p, *e, *_nucleus);
 			}
@@ -523,7 +523,6 @@ void NuWro::pot_report(ostream& o)
 	double tot=0;
 	if(_detector)
 	{
-	  //CT: Something wrong with this calculation for uB
 		double pd=_detector->nucleons_per_cm2();
 
 		for(int i=0;i<_procesy.size();i++)
@@ -537,16 +536,13 @@ void NuWro::pot_report(ostream& o)
 		double epp=tot*pd*_beam->nu_per_POT();
 	
 		o<<"Total: events per POT= "<<epp<<endl
-		 <<"       POT per event = "<<1/epp<<endl;
+		 <<"       POT per event = "<<1.0/epp<<endl;
 		o<<" BOX nuclons per cm2 = "<<pd<<endl;
 		o<<"Total cross section  = "<<tot<<" cm2"<<endl;
 		o<<"Reaction probability = "<<tot*pd<<endl;
-		o<<"Average BOX density  = "<<_detector->density()/g*cm3<<" g/cm3"<< endl;
-		
+		o<<"Average BOX density  = "<<_detector->density()/g*cm3<<" g/cm3"<< endl;		
 		o<<"Estimated BOX mass   = "<<_detector->vol_mass()/kg<<" kg"<<endl;	
-
 		o<<"Fraction of protons  = "<<_detector->frac_proton()<<endl;
-
 		o << "Total POT: " << p.number_of_events/epp << std::endl;
 
 	}

--- a/src/params.xml
+++ b/src/params.xml
@@ -442,6 +442,10 @@
   <param name="hyp_axial_mass" type="text" ctype="double" default="1030">
     <description>Axial mass used in hyperon production></description>
   </param>
+ <param name="hyp_effmass" type="checkbox" ctype="bool" default="false">
+  <description>Use hyperon effective mass if cross section</description>
+</param>
+
   <param name="kaskada_on" type="checkbox" ctype="bool" default="1">
     <description><![CDATA[use (1) or not (0) the cascade]]></description>
   </param>
@@ -531,9 +535,14 @@
   <!-- <param name="hyp_kaskada_cutoff" type="checkbox" ctype="bool" default="0">
     <description>Hyperon kinetic energy cutoff</description>
   </param> -->
-  <param name="hyp_Eb" type="text" ctype="double" default="30">
-    <description>Hyperon binding energy at max density</description>
+  <param name="hyp_Lambda_Eb" type="text" ctype="double" default="30">
+    <description>Lambda binding energy at max density</description>
   </param>
+  <param name="hyp_Sigma_Eb" type="text" ctype="double" default="30">
+    <description>Sigma binding energy at max density</description>
+  </param>
+
+
 </params>
 
 <!--

--- a/src/params_all.h
+++ b/src/params_all.h
@@ -102,6 +102,7 @@ PARAM(double,hyp_g2_Re_part,0)\
 PARAM(double,hyp_g2_Im_part,0)\
 PARAM(bool,hyp_su3_sym_breaking,0)\
 PARAM(double,hyp_axial_mass,1030)\
+PARAM(bool,hyp_effmass,false)\
 PARAM(bool,kaskada_on,1)\
 PARAM(double,kaskada_w,7)\
 PARAM(bool,kaskada_redo,0)\
@@ -119,5 +120,6 @@ PARAM(int,kaskada_NN_corr,1)\
 PARAM(int,kaskada_piN_xsec,1)\
 PARAM(bool,pauli_blocking,1)\
 PARAM(bool,mixed_order,1)\
-PARAM(double,hyp_Eb,30)\
+PARAM(double,hyp_Lambda_Eb,30)\
+PARAM(double,hyp_Sigma_Eb,30)\
 

--- a/src/pdg.h
+++ b/src/pdg.h
@@ -550,6 +550,22 @@ namespace PDG
         or pdg == pdg_SigmaP;
   }
 
+  //added C Thorpe Jan 2021
+  inline bool Lambda (int pdg)
+  {
+  return pdg == pdg_Lambda;
+  }
+
+
+  //added C Thorpe Jan 2021
+  inline bool Sigma (int pdg)
+  {
+  return pdg == pdg_Sigma
+      or pdg == pdg_SigmaM
+      or pdg == pdg_SigmaP;
+  }
+
+
 };
 
 

--- a/src/proctable.h
+++ b/src/proctable.h
@@ -31,6 +31,12 @@ enum {
      pion_tpp=24,
      pion_abs=25, 
 
+     // hyperon processes
+     hyperon_el=30, //elastic 
+     hyperon_ls=31, // lambda -> sigma
+     hyperon_sl=32, // sigma -> lambda
+ 
+
      jailed=99,
      escape=100
      };

--- a/src/qelevent1.cc
+++ b/src/qelevent1.cc
@@ -30,6 +30,7 @@
 double qelevent1(params&p, event & e, nucleus &t,bool nc)
 ////////////////////////////////////////////////////////////////////////
 {
+
   e.weight=0;
 
   particle nu=e.in[0];               // neutrino
@@ -88,7 +89,7 @@ double qelevent1(params&p, event & e, nucleus &t,bool nc)
       case 0: _E_bind = 0;        break;
       case 1: _E_bind = p.nucleus_E_b; break;
       case 2: _E_bind = t.Ef(N0) + p.kaskada_w;break; //temporary
-      case 3: _E_bind = bodek_binding_energy(N0, t.A()); break;
+      case 3: _E_bind = bodek_binding_energy(N0, t.p , t.n); break;
       case 4: _E_bind = binen (N0.p(), p.nucleus_p, p.nucleus_n); break;
       case 5: _E_bind = deuter_binen (N0.p());break; //deuterium 
       case 6: _E_bind = p.nucleus_E_b;      break; //deuterium like Fermi gas
@@ -149,6 +150,8 @@ double qelevent1(params&p, event & e, nucleus &t,bool nc)
             exit(9);
   }
 
+
+
   // (KN) TODO: momentum dependent potential should be independent of this code
   if (q2 != 0) // there was scattering
     if(p.qel_kinematics==3)
@@ -157,8 +160,13 @@ double qelevent1(params&p, event & e, nucleus &t,bool nc)
   vect nu4 = nu;
   nu4.boost (-N0.v ());  // go to nucleon rest frame
   double Enu0 = nu4.t;     // neutrino energy in target frame
+
   xsec = jakobian * qel_sigma(Enu0, q2, kind, nu.pdg<0, lepton.mass(), N0.mass());
-  
+
+
+
+ 
+ 
   /*
   /////////////////////////////////////////////////////////
   // Aligarh Model for QEL (includes second class current)

--- a/src/scatter.cc
+++ b/src/scatter.cc
@@ -120,123 +120,109 @@ int scatter_n (int n, particle p1, particle p2,
     return 1;
   }
 
-//added by CThorpe
 
-//solve kinematics with hyperon BE using self consistency method:
+// NOT CURRENTLY USED
+// Solve kinematics with hyperon BE using self consistency method:
 
-//Boost initial particles into CMS
-//Generate a scattering angle for the hyperon
-//guess an effective mass for the hyperon
-//boost back to lab
-//check if eff mass is consistent with on shell hyperon modified for binding energy
-//if not guess a new value and repeat until they match
+// Boost initial particles into CMS
+// Generate a scattering angle for the hyperon
+// Guess an effective mass for the hyperon
+// Boost back to lab
+// Check if eff mass is consistent with on shell hyperon modified for binding energy
+// If not, guess a new value and repeat until they match
 
 double scatter2_with_BE_SC(particle p1,particle p2, particle &p3, particle &p4, double Y_Eb){
 
-  double range = 0.01; //maximum allowed disagreement between two calculations of effective mass
+  double range = 0.01; // Maximum allowed disagreement between two calculations of effective mass
 
-  //compute the 4 momentum of cms
- vect suma = vect (p1) + vect (p2);
+  // Compute the 4 momentum of cms
+  vect suma = vect (p1) + vect (p2);
   if(suma*suma<=0) return 0;
 
-  double s = suma*suma; //squared cms energy
+  double s = suma*suma; // Squared cms energy
   double pcms2=0;
-
-
-  // std::cout << std::endl;
-  // std::cout << "Method 1" << std::endl;
 
   particle hyp = p4;
   particle lep = p3;
 
   vec vcms = suma.v();
 
-  // p1.boost(-vcms);
-  // p2.boost(-vcms);
-
-  //make initial guess of hyperon effective mass as nucleon mass minus lepton mass
-  //this gaurentees this initial attempt will always succeed
+  // Make initial guess of hyperon effective mass as nucleon mass minus lepton mass
+  // this gaurentees this initial attempt will always succeed
 
   hyp.set_mass(sqrt(s) - lep.mass()-3);
 
-  //perform the decay IN THE CMS using this initial guess
+  // Perform the decay IN THE CMS using this initial guess
 
   ::decay(vect(p1)+vect(p2), hyp, lep);
 
-      //get the direction of the 3 momentum of the hyperon in the cms
-      vec unit_vec = vec(hyp) / vec(hyp).length();
+  // Get the direction of the 3 momentum of the hyperon in the cms
+  vec unit_vec = vec(hyp) / vec(hyp).length();
 
-      //boost to lab
+  // Boost to lab
 
-      hyp.boost(vcms);
-      lep.boost(vcms);
-     
- double diff=0;
-  
-//cap at 50 iterations (usually finds eff mass in <5) 
-  for(int i=0;i<50;i++){
-    
-
-  //check is hyperon's 4 momentum consistent with BE adjustment
- 
-  double calc_energy = hyp.t;
-  double target_energy =  sqrt(p4.mass()*p4.mass() + hyp.length()*hyp.length()) - Y_Eb;
-
-    //break the loop when the values are close enough or if step size falls below target size
-    if(calc_energy < target_energy + range/2 && calc_energy > target_energy - range/2) break; 
-
-
-    diff = calc_energy - target_energy; //difference between two energy calculations - when this is zero you have correct effective mass
-
-    //boost back to cms
-    hyp.boost(-vcms);
-    lep.boost(-vcms);
-    
- double hyp_mass = hyp.mass();
-
-  label:
-    //get new estimate of hyperon effective mass
-
-    hyp.set_mass(hyp_mass - diff);
-
-
-    //recalculate the cms momentum
-    //if this fails then pcms2=-1
-
-    pcms2 = cms_momentum2(s,lep.mass2(),hyp.mass2());
-
-    //if unable to generate kinematics for this 
-    if(pcms2 < 0 && abs(diff) > range/2){ 
-
-diff /= 2;
- goto label;
-
-    }
-    else if(abs(diff)<range/2){
-
-      return 0;
-    }
- 
-  hyp.set_momentum(unit_vec * sqrt(pcms2) );
-  lep.set_momentum(-unit_vec * sqrt(pcms2) );
-
-
-  //boost back to lab
   hyp.boost(vcms);
-      lep.boost(vcms);
+  lep.boost(vcms);
+
+  double diff=0;
+
+  // Cap at 50 iterations (usually finds eff mass in <5) 
+  for(int i=0;i<50;i++){
+
+     // Check is hyperon's 4 momentum consistent with BE adjustment
+
+     double calc_energy = hyp.t;
+     double target_energy =  sqrt(p4.mass()*p4.mass() + hyp.length()*hyp.length()) - Y_Eb;
+
+     // Break the loop when the values are close enough or if step size falls below target size
+     if(calc_energy < target_energy + range/2 && calc_energy > target_energy - range/2) break; 
+
+     diff = calc_energy - target_energy; // Difference between two energy calculations - when this is zero you have correct effective mass
+
+     // Boost back to cms
+     hyp.boost(-vcms);
+     lep.boost(-vcms);
+
+     double hyp_mass = hyp.mass();
+
+     label:
+
+     // Get new estimate of hyperon effective mass
+
+     hyp.set_mass(hyp_mass - diff);
+
+     // Recalculate the cms momentum
+     // If this fails then pcms2=-1
+
+     pcms2 = cms_momentum2(s,lep.mass2(),hyp.mass2());
+
+     // If unable to generate kinematics for this 
+     if(pcms2 < 0 && abs(diff) > range/2){ 
+
+        diff /= 2;
+        goto label;
+
+     }
+     else if(abs(diff)<range/2) return 0;
+ 
+     hyp.set_momentum(unit_vec * sqrt(pcms2) );
+     lep.set_momentum(-unit_vec * sqrt(pcms2) );
+
+     // Boost back to lab
+     hyp.boost(vcms);
+     lep.boost(vcms);
 
 
   }
-  
 
-  //having found the correct effective mass,
-  //set the outgoing particle 4 momenta and masses
+
+  // Having found the correct effective mass, set
+  // the outgoing particle 4 momenta and masses
 
   double hyp_mass = p4.mass();
 
   p3 = lep;
   p4 = hyp;
-
 
   double q2 = (lep.t - p1.t)*(lep.t - p1.t) - (vec(p1)-vec(lep))*(vec(p1)-vec(lep));
 
@@ -244,21 +230,22 @@ diff /= 2;
 }
 
 
-//Modified cms energy trick
+// NOT CURRENTLY USED
+// Modified cms energy trick
 
 double scatter2_with_BE(particle p1,particle p2, particle &p3, particle &p4, double Y_Eb, vec &cms_dir){
 
   particle hyp = p4;
   particle lep = p3;
 
-  //compute the 4 momentum of cms blob
- vect suma = vect (p1) + vect (p2);
+  // Compute the 4 momentum of cms blob
+  vect suma = vect (p1) + vect (p2);
   if(suma*suma<=0) return 0;
 
-  //to boost to cms
+  // To boost to cms
   vec vcms = suma.v();
 
-  //generate random unit vector in true cms
+  // Generate random unit vector in true cms
 
   double xx,yy,zz,rr;
 
@@ -269,95 +256,101 @@ double scatter2_with_BE(particle p1,particle p2, particle &p3, particle &p4, dou
       zz = 2 * frandom () - 1;
       
       
-}
+    }
  while ((rr = sqrt(xx * xx + yy * yy + zz * zz)) > 1);
+
+ rr=sqrt(xx*xx+yy*yy+zz*zz);
 
  vec dir(xx/rr,yy/rr,zz/rr);
 
  vect true_cms_dir(1,dir);
- 
- //boost this vector to the lab frame
+
+ // Boost this vector to the lab frame
  true_cms_dir.boost(vcms);
 
-  //take the total initial 4 momentum and add the hyperon BE
-  vect suma_be = suma;
-  suma_be.t += Y_Eb;
+ // Take the total initial 4 momentum and add the hyperon BE
+ vect suma_be = suma;
+ suma_be.t += Y_Eb;
 
-  //to boost to modified cms
-  vec vcms_be = suma_be.v();
+ // To boost to modified cms
+ vec vcms_be = suma_be.v();
 
-//boost direction vector into modified cms
-  true_cms_dir.boost(-vcms_be);
+ // Boost direction vector into modified cms
+ true_cms_dir.boost(-vcms_be);
 
-  //try to decay the CMS
+ // Try to decay the CMS
 
-  double s = suma_be*suma_be; //squared cms energy
-double pp = cms_momentum2(s,p3.mass2(),p4.mass2());
+ double s = suma_be*suma_be; // Squared cms energy
+ double pp = cms_momentum2(s,p3.mass2(),p4.mass2());
 
-//forbidden by kinematics
- if(pp <= 0 ) return 0;
+
+ if(pp <= 0 ) return 0; // Process not allowed by kinematics
 
  lep.set_momentum( vec(true_cms_dir)/vec(true_cms_dir).length() * sqrt(pp)  );
  hyp.set_momentum( - vec(true_cms_dir)/vec(true_cms_dir).length() * sqrt(pp)  );
 
-  lep.t = sqrt(lep.mass()*lep.mass() + pp );
+ lep.t = sqrt(lep.mass()*lep.mass() + pp );
 
  hyp.t = sqrt(hyp.mass()*hyp.mass() + pp );
 
 
-//record direction of outgoing lepton in cms for use in rescale_momenta
+ // Record direction of outgoing lepton in cms for use in rescale_momenta
  cms_dir = dir;
 
-//boost back to lab
+ // Boost back to lab
  lep.boost(vcms_be);
-  hyp.boost(vcms_be);
- 
-   //subtract BE off hyperon energy 
-   hyp.t -= Y_Eb;
+ hyp.boost(vcms_be);
+
+ // Subtract BE off hyperon energy 
+ hyp.t -= Y_Eb;
 
 
-  //calculate the q2
+ // Calculate the q2
 
-   double q2 = (lep.t - p1.t)*(lep.t - p1.t) - (vec(p1)-vec(lep))*(vec(p1)-vec(lep));
+ double q2 = (lep.t - p1.t)*(lep.t - p1.t) - (vec(p1)-vec(lep))*(vec(p1)-vec(lep));
 
+ p3 = lep;
+ p4 = hyp;
 
-     p3 = lep;
-     p4 = hyp;
-
-  return q2;
+ return q2;
 
 
 }
 
-//given the 4 momentum of the cms object pcms
-//and a direction in the cms you want it to decay in cms_dir
-//into two particles p3 and p4.
+// Takes total 4 momentum pcms, generates kinematics for particles
+// p3 and p4 with p3 travelling along cms_dir in the CMS
 
-//cms_dir should be unit vector
-bool rescale_momenta(vect pcms, vec cms_dir, particle &p3, particle &p4,double Y_Eb){
+//bool rescale_momenta(vect pcms, vec cms_dir, particle &p3, particle &p4,double Y_Eb){
+bool rescale_momenta(vect pcms,vec cms_dir,particle &p3, particle &p4){
 
-  pcms.t += Y_Eb;
+   // Just to make sure
+   cms_dir *= 1.0/cms_dir.length();
 
-  vec vcms_be = pcms.v();
+   vec vcms_be = pcms.v();
 
-  double s = pcms*pcms;
+   double s = pcms*pcms;
 
-  double pp = cms_momentum2(s,p3.mass2(),p4.mass2());
+   double pp = cms_momentum2(s,p3.mass2(),p4.mass2());
 
-  if(pp < 0) return false; //process not allowed by kinematics
+   if(pp < 0) return false; // Process not allowed by kinematics
 
-  p3.set_momentum( cms_dir * sqrt(pp) );
-  p4.set_momentum( -cms_dir * sqrt(pp) );
+   p3.set_momentum( cms_dir * sqrt(pp) );
+   p4.set_momentum( -cms_dir * sqrt(pp) );
 
-  p3.t = sqrt(p3.mass()*p3.mass() + pp );
+   p3.t = sqrt(p3.mass()*p3.mass() + pp );
+   p4.t = sqrt(p4.mass()*p4.mass() + pp );
 
- p4.t = sqrt(p4.mass()*p4.mass() + pp );
+   p3.boost(vcms_be);
+   p4.boost(vcms_be);
 
- p3.boost(vcms_be);
- p4.boost(vcms_be);
+   /*
+   // Check 4 momentum
+      std::cout << std::endl;
+      std::cout << pcms << std::endl;
+      std::cout << vect(p3) << std::endl;
+      std::cout << vect(p4) << std::endl;
+   */
 
- p4.t -= Y_Eb;
-
-  return true;
+   return true;
 
 }

--- a/src/scatter.h
+++ b/src/scatter.h
@@ -24,7 +24,8 @@ double scatter2_with_BE_SC(particle p1,particle p2, particle &p3, particle &p4, 
 
 double scatter2_with_BE(particle p1,particle p2, particle &p3, particle &p4, double Y_Eb, vec &cms_dir);
 
-bool rescale_momenta(vect pcms, vec cms_dir, particle &p3, particle  &p4, double Y_Eb);
+//bool rescale_momenta(vect pcms, vec cms_dir, particle &p3, particle  &p4, double Y_Eb);
+bool rescale_momenta(vect pcms, vec cms_dir, particle &p3, particle  &p4);
 
 #endif
 


### PR DESCRIPTION
### QEL Hyperon Production, Hyperon FSI and Flexible Flux/Geometry

These additions affect two areas:

1. A new quasielastic hyperon production channel, simulating the antineutrino-nucleon interaction and final state interactions for hyperons. A related change to the DIS channel preserves hyperons  produced this way.
2. Changes to flux/geometry handling to enable users to use their own unit conventions for lengths, density and window positioning.

Below is a detailed list of changes:

**QEL Hyperon Production**

This simulates the quasielastic production of hyperons (Lambda, Sigma0 and Sigma- baryons) from nucleons and nuclei. The model includes pseudotensor second class current and SU(3) symmetry breaking corrections. 

1. New event generator code `hypevent.cc` generates the primary interaction for the three sub channels and decides which to use. The cross sections themselves are calculated inside `hyperon_interaction.cc`. This file has several functions that calculate the hyperon production differential cross sections, the one currently in use is `Singh_Model2`. The corresponding form factor calculators have been added to `ff.cc`.

2. `nuwro.cc` is modified to include this new channel.

3. `params.xml` includes several new parameters: 
A switch for the hyperon production channel: `dyn_hyp_cc`.
Switches for the three sub channels: `hyp_lambda`, `hyp_sigma_zero` and `hyp_sigma_minus`.
Setting of the second class current strength: `hyp_g2_Re_part`, `hyp_g2_Im_part`.
Switch for the SU(3) symmetry corrections: `hyp_su3_sym_breaking`.
Separate axial mass parameter: `hyp_axial_mass`.
Strengths of the Lambda-nucleus and Sigma-nucleus potentials: `hyp_Lambda_Eb` and `hyp_Sigma_Eb`.

These have all been added to `data/params.txt`.

4. A new function `PDG::hyperon` was added to `pdg.h` that returns true if given the pdg code of a Lambda or Sigma. 

5. Several new functions are added to `scatter.cc`:
`scatter2_with_BE` and `scatter2_with_BE_SC` generate kinematics for a 2->2 process where one of the final state particles is off shell. _These are not currently used._
`rescale_momenta` used to converting kinematics for a Lambda production event to those of a Sigma0 event, keeping all the angles in the CMS the same. Used for comparing their cross sections in `hypevent.cc`. 

6. New functions to retrieve binding energy for Bodek-Ritchie nuclear model. _Not currently used_. 

**DIS Hyperons**

It appears that by default Pythia will decay hyperons. Changes made to DIS code to stabilize hyperons produced this way.

1. `dis/dis_pdg.h` has pdg codes for hyperons added. 

2. `dis/disevent.cc`,`dis/dishadr.cc` and `dis/reshadr.cc` were changed to instruct Pythia not to decay hyperons. 

3. `dis/disevent.cc` must now be passed the nucleus object to calculate the hyperon potential.

**Hyperon FSI**

Changes include final state interactions for hyperons. 

1. Changes to `kaskada7.cc` :

Now adds hyperons to the particle queue alongside nucleons and pions inside `prepare_particles` and modifies the hyperon's kinematics to propagate it in the potential (energy is added if the potential is attractive, subtracted if the potential is repulsive).

`move_particle` modified to check if hyperon should be jailed at the end of every step. Similarly in `leave_nucleus` and `finalize_interaction`, check if the hyperon should be jailed when trying to exit the nucleus of after an interaction.

`make_interaction` checks if a secondary interaction involved a hyperon and if that hyperon has switched families (Lambda <-> Sigma) it will change the value of the potential that hyperon is propagating through accordingly. If the hyperon cannot be moved to the new potential this secondary interaction is ignored.

2. Changes to `Interaction.cc`:

`total_cross_sections` was modified to check if it has a hyperon, There is a new function, `get_hyp_xsec` that retrieves the cross sections for hyperon FSI which is invoked.

Similarly in `particle_scattering`, if the particle given is a hyperon, calls a new function `hyperon_scattering` to generate the interaction. 

New function `get_hyp_xsec` calculates some kinematic variables for the hyperon-nucleon cross section formulae, then calls functions in `hyperon_cascade.cc` that gets the cross sections themselves. 

New function `hyperon_scattering` performs the hyperon-nucleon scatter itself. Calls the `hyperon_state` function from `hyperon_cascade.cc` to choose a final state by Monte Carlo, sets the process ID and then generates the kinematics using functions in `scatter.cc`. 

New function `hyperon_process_id` to get hyperon process ID. enum at the top of `Interaction.h` modified to accommodate hyperon process codes. 

3. `proctable.h` was expanded to include three categories of hyperon secondary interactions, elastic, Lambda->Sigma and Sigma->Lambda. The corresponding counters are `nod[15]`,`nod[16]` and `nod[17]`. 

4. `hyperon_cascade.cc` contains a collection of functions for calculating the hyperon-nucleon cross sections used in the cascade, calculating the phase space factors appearing in the formulae and selecting a hyperon-nucleon final state by Monte Carlo. 

**Flux/Geometry Changes**

Unit conventions used by ND280 were previously hard coded in. Several new parameters have been introduced to perform unit conversions so other fluxes and geometries can be used. 

1. Changes to `params.xml`:

The following new parameters are used:

`geom_length_units`, the length units used by the detector geometry.
`geom_density_convert` takes the density used by the geometry and converts to g/cm3. The required value has been added to `data/target/ND280.txt`.
`beam_length_units`, the length units used for the beam window placement (units of the `xnu`,`ynu` and `znu` branches of the tree containing the flux rays). 
`beam_pot_per_file` the number of protons on target for each flux file used. Currently assumes this is the same for every file. If this is not supplied in the parameters then NuWro assumes ND280 POT conventions. 

These use ND280 conventions by default.

2. Changes to `beamRF.h`:

The `beamRF` constructor now uses `beam_length_units` to calculate any conversion factors. It also reads in the POT per file from params. 

`nu_from_event` now reads the z coordinate from the event and applies and required unit conversions. 

3. Changes to `geomy.h`:

`geomy` constructor sets up length and density unit conversions using the values of `geom_length_units` and `geom_density_convert`. 

These conversions are used in calculating masses of detector volumes and number densities.