### PR TITLE
Fix a bug where multiple atmospheric flux is not handled properly

### DIFF
--- a/src/beam_atmo.h
+++ b/src/beam_atmo.h
@@ -44,6 +44,7 @@ class beam_atmo: public beam
 			stringstream in(p.beam_atmo_files);
 			int pdg=0;
 			string fname;
+			double s0=0,s1=0;
 			while(in >> pdg >> fname)
 			{
 				if(abs(pdg)==12 || abs(pdg)== 14 || abs(pdg)==16)
@@ -66,7 +67,7 @@ class beam_atmo: public beam
 				bin b;
 				b.pdg=pdg;
 				string line;
-				double s0=0,s1=0,w,E;    
+				double w,E;    
 				while(getline(atmo,line))
 				if(line[0]!='#')
 				{


### PR DESCRIPTION
The value s0 and s1 is the CDF for the weight of bins, thus when `p.beam_atmo_files` has multiple lines (usually seen when different flavors of neutrino being present), the value should not be reset after each file is processed.