### PR TITLE
Nuwro 25.03.2

### DIFF
--- a/src/main.cc
+++ b/src/main.cc
@@ -14,9 +14,9 @@ int main(int argc, char** argv)
  |                                  `-/+os+s  ./ohmN:.    sNNNy:`   .---.+`   |
  |    |\ |     |  |  _  _           :oooyysy: +oodMMd-`  .MMMMM/-   -----s/   |
  |    | \| |_| |/\| |  (_)           `.`oyy+d`   `mMMo-   yMMMyo`   .----d.   |
- |             __        __   __        .yyyoo    :MMN:.  :MMho.    `---h:    |
- |              _) /|   /  \ (__\        :yyoh-    sMMh-`.mMho-     ---h:     |
- |             /__  | . \__/  __/         oyy+h    `mMM+-mMho-     ---h:      |
+ |             __   __     __   __        .yyyoo    :MMN:.  :MMho.    `---h:  |
+ |              _) |__    /  \  __\        :yyoh-    sMMh-`.mMho-     ---h:   |
+ |             /__  __| . \__/  __/         oyy+h    `mMM+-mMho-     ---h:    |
  |                                        .yyys+    -MMNmMh+-     ---h:       |
  |                                         :yyod.    sMMMh+-     ---h:        |
  |   Wrocław Neutrino Event Generator       oyy+h    `mMh-+.    ---h:         |

--- a/src/main.cc
+++ b/src/main.cc
@@ -14,9 +14,9 @@ int main(int argc, char** argv)
  |                                  `-/+os+s  ./ohmN:.    sNNNy:`   .---.+`   |
  |    |\ |     |  |  _  _           :oooyysy: +oodMMd-`  .MMMMM/-   -----s/   |
  |    | \| |_| |/\| |  (_)           `.`oyy+d`   `mMMo-   yMMMyo`   .----d.   |
- |             __   __     __   __        .yyyoo    :MMN:.  :MMho.    `---h:  |
- |              _) |__    /  \  __\        :yyoh-    sMMh-`.mMho-     ---h:   |
- |             /__  __| . \__/  __/         oyy+h    `mMM+-mMho-     ---h:    |
+ |             __   __     __   __      .yyyoo    :MMN:.  :MMho.    `---h:    |
+ |              _) |__    /  \  __\      :yyoh-    sMMh-`.mMho-     ---h:     |
+ |             /__  __| . \__/  __/       oyy+h    `mMM+-mMho-     ---h:      |
  |                                        .yyys+    -MMNmMh+-     ---h:       |
  |                                         :yyod.    sMMMh+-     ---h:        |
  |   Wrocław Neutrino Event Generator       oyy+h    `mMh-+.    ---h:         |

--- a/src/mecevent_2020Valencia.cc
+++ b/src/mecevent_2020Valencia.cc
@@ -67,11 +67,6 @@ void mecevent_2020Valencia (params & p, event & e, nucleus & t, bool cc)
   particle meclepton_3p3h;
   ap=(e.in[0].pdg<0);
 
-  if ( std::abs(e.in[0].pdg) != 14 ) {
-    cerr << "Only muon neutrino available \n";
-    e.weight = 0;
-    return;
-  }
 
   meclepton_3p3h.pdg = meclepton.pdg = e.in[0].pdg-1+2*ap;
   meclepton.set_mass (PDG::mass (meclepton.pdg)); //set mass coresponding to pdg
@@ -84,13 +79,13 @@ void mecevent_2020Valencia (params & p, event & e, nucleus & t, bool cc)
 
   // Binding energy / Correlation within the medium 
 
-  switch(p.nucleus_p) {
-    case 6: Bmec = ap ? E_corr[1] : E_corr[0]; break;
-    case 8: Bmec = ap ? E_corr[3] : E_corr[2]; break;
-    case 40: Bmec = ap ? E_corr[5] : E_corr[4]; break;
-    default: Bmec = ap ? E_corr[1] : E_corr[0]; break;  // By default Carbon grid is set in src/nucleus.cc so Bmec is set as E_corr of Carbon
-  }
- 
+  if (p.nucleus_p > 12) {
+    Bmec = ap ? E_corr[5] : E_corr[4];
+  } else if ( (p.nucleus_p <=12) and (p.nucleus_p > 6) ) {
+      Bmec = ap ? E_corr[3] : E_corr[2];
+    } else {
+        Bmec = ap ? E_corr[1] : E_corr[0];
+      } 
 
 
   double q0max = e.in[0].energy() - ml - Bmec;

--- a/src/nucleus.cc
+++ b/src/nucleus.cc
@@ -50,13 +50,13 @@ nucleus::nucleus(params &par):
 
 
   //Attaching appropriate hadronic grids according to the nucleus configuration 
-  if ((p+n) == 40) {  // Calcium grid 
+  if (p > 12) {  // Calcium grid 
     W00.Attach_ptr(Ca40_W00pp, Ca40_W00np, Ca40_W00pn, Ca40_W00_3p3h);
     W03.Attach_ptr(Ca40_W03pp, Ca40_W03np, Ca40_W03pn, Ca40_W03_3p3h);
     W11.Attach_ptr(Ca40_W11pp, Ca40_W11np, Ca40_W11pn, Ca40_W11_3p3h);
     W12.Attach_ptr(Ca40_W12pp, Ca40_W12np, Ca40_W12pn, Ca40_W12_3p3h);
     W33.Attach_ptr(Ca40_W33pp, Ca40_W33np, Ca40_W33pn, Ca40_W33_3p3h);
-  } else if ((p+n) == 16) { // Oxygen grid
+  } else if ((p > 6) and (p<=12)) { // Oxygen grid
       W00.Attach_ptr(O16_W00pp, O16_W00np, O16_W00pn, O16_W00_3p3h);
       W03.Attach_ptr(O16_W03pp, O16_W03np, O16_W03pn, O16_W03_3p3h);
       W11.Attach_ptr(O16_W11pp, O16_W11np, O16_W11pn, O16_W11_3p3h);


### PR DESCRIPTION
# `main.cc` now says 25.03

# MEC tables available for all neutrino flavors

# MEC tables available for all nuclei and their isotopes (without extrapolation)

For eg. MEC 2020 Valencia model will use Calcium grid for any nucleus with `p.nucleus_p>12`. Corresponding `Bmec` is used.

Rules for assigning the MEC tables are as follows:
- `p.nucleus_p<=6` : Carbon table is used
- `6<p.nucleus_p<=12` : Oxygen table is used
- `p.nucleus_p>12` : Calcium table is used
 
