### PR TITLE
NuWro version compatible with new ROOT version and new macOS versions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,14 +15,14 @@ DEBUG         = 1
 #DEBUGON = -g
 ifeq ($(OS),Darwin)
   # Flags for OSX
-  CXXFLAGS      = `${ROOTSYS}/bin/root-config --cflags` -fPIC -O2 $(DEBUGON) -I src -Wall -Wno-unused-variable -Wno-sign-compare -Wno-unused-function -Wno-unused-but-set-variable -Wreorder -Wmissing-braces $(QTINCLUDEDIRS) -DVERSION=\"$(VERSION)\" -I/Users/hprasad/ROOTEGPythia6/build/Darwin/include
+ CXXFLAGS      = `${ROOTSYS}/bin/root-config --cflags` -fPIC -O2 $(DEBUGON) -I src -Wall -Wno-unused-variable -Wno-sign-compare -Wno-unused-function -Wno-unused-but-set-variable -Wreorder -Wmissing-braces $(QTINCLUDEDIRS) -DVERSION=\"$(VERSION)\" -I${ROOTEGPythia6_ROOT}/include
 else
   # Flags for others
- CXXFLAGS      = `${ROOTSYS}/bin/root-config --cflags` -fPIC -O2 $(DEBUGON) -I src -Wl,--no-as-needed -Wall -Wno-unused-variable -Wno-sign-compare -Wno-unused-function -Wno-unused-but-set-variable -Wreorder -Wmissing-braces $(QTINCLUDEDIRS) -DVERSION=\"$(VERSION)\" -I/Users/hprasad/ROOTEGPythia6/build/Darwin/include
+ CXXFLAGS      = `${ROOTSYS}/bin/root-config --cflags` -fPIC -O2 $(DEBUGON) -I src -Wl,--no-as-needed -Wall -Wno-unused-variable -Wno-sign-compare -Wno-unused-function -Wno-unused-but-set-variable -Wreorder -Wmissing-braces $(QTINCLUDEDIRS) -DVERSION=\"$(VERSION)\" -I${ROOTEGPythia6_ROOT}/include
 # CXXFLAGS      = `${ROOTSYS}/bin/root-config --cflags` --std=c++17 -fPIC -O2 $(DEBUGON) -I src -Wl,--no-as-needed -Wall -Wno-deprecated-register -Wno-unused-variable -Wno-sign-compare -Wno-unused-function -Wno-unused-but-set-variable -Wno-reorder $(QTINCLUDEDIRS)
  
 endif
-LDFLAGS       = `${ROOTSYS}/bin/root-config --libs` -L/Users/hprasad/ROOTEGPythia6/build/Darwin/lib -Wl,-rpath,/Users/hprasad/ROOTEGPythia6/build/Darwin/lib -lEGPythia6 -lPythia6 -lGeom -lMinuit -lgfortran $(QTLIBS)
+LDFLAGS       = `${ROOTSYS}/bin/root-config --libs` -L${ROOTEGPythia6_ROOT}/lib -Wl,-rpath,${ROOTEGPythia6_ROOT}/lib -lEGPythia6 -lPythia6 -lGeom -lMinuit -lgfortran $(QTLIBS)
 LD            = g++
 CXX           = g++
 CC            = g++

--- a/Makefile
+++ b/Makefile
@@ -15,14 +15,14 @@ DEBUG         = 1
 #DEBUGON = -g
 ifeq ($(OS),Darwin)
   # Flags for OSX
-  CXXFLAGS      = `${ROOTSYS}/bin/root-config --cflags` -fPIC -O2 $(DEBUGON) -I src -Wall -Wno-unused-variable -Wno-sign-compare -Wno-unused-function -Wno-unused-but-set-variable -Wreorder -Wmissing-braces $(QTINCLUDEDIRS) -DVERSION=\"$(VERSION)\"
+  CXXFLAGS      = `${ROOTSYS}/bin/root-config --cflags` -fPIC -O2 $(DEBUGON) -I src -Wall -Wno-unused-variable -Wno-sign-compare -Wno-unused-function -Wno-unused-but-set-variable -Wreorder -Wmissing-braces $(QTINCLUDEDIRS) -DVERSION=\"$(VERSION)\" -I/Users/hprasad/ROOTEGPythia6/build/Darwin/include
 else
   # Flags for others
- CXXFLAGS      = `${ROOTSYS}/bin/root-config --cflags` -fPIC -O2 $(DEBUGON) -I src -Wl,--no-as-needed -Wall -Wno-unused-variable -Wno-sign-compare -Wno-unused-function -Wno-unused-but-set-variable -Wreorder -Wmissing-braces $(QTINCLUDEDIRS) -DVERSION=\"$(VERSION)\"
+ CXXFLAGS      = `${ROOTSYS}/bin/root-config --cflags` -fPIC -O2 $(DEBUGON) -I src -Wl,--no-as-needed -Wall -Wno-unused-variable -Wno-sign-compare -Wno-unused-function -Wno-unused-but-set-variable -Wreorder -Wmissing-braces $(QTINCLUDEDIRS) -DVERSION=\"$(VERSION)\" -I/Users/hprasad/ROOTEGPythia6/build/Darwin/include
 # CXXFLAGS      = `${ROOTSYS}/bin/root-config --cflags` --std=c++17 -fPIC -O2 $(DEBUGON) -I src -Wl,--no-as-needed -Wall -Wno-deprecated-register -Wno-unused-variable -Wno-sign-compare -Wno-unused-function -Wno-unused-but-set-variable -Wno-reorder $(QTINCLUDEDIRS)
  
 endif
-LDFLAGS       = `${ROOTSYS}/bin/root-config --libs` -lPythia6  -lEG -lEGPythia6 -lGeom -lMinuit -lgfortran $(QTLIBS)
+LDFLAGS       = `${ROOTSYS}/bin/root-config --libs` -L/Users/hprasad/ROOTEGPythia6/build/Darwin/lib -Wl,-rpath,/Users/hprasad/ROOTEGPythia6/build/Darwin/lib -lEGPythia6 -lPythia6 -lGeom -lMinuit -lgfortran $(QTLIBS)
 LD            = g++
 CXX           = g++
 CC            = g++

--- a/README_ROOTEGPythia6.md
+++ b/README_ROOTEGPythia6.md
@@ -1,23 +1,49 @@
-It is assumed that you have already installed ROOT v30 or higher 
+🛑 It is assumed that you have already installed `ROOT v30` or higher  
 If not please visit [cern root](https://root.cern/install/build_from_source/) for building root from source 
 
-To setup ROOTEGPythia6 run `./setupROOTEGPythia6.sh`. In order to do so first make `setupROOTEGPythia6.sh` an executable file. 
+💡 You have to run this script only once setup ROOTEGPythia6.
 
+## How to execute the script
+
+First make `setupROOTEGPythia6.sh` an executable file. 
 ```bash
 chmod +x setupROOTEGPythia6.sh
 ```
 
-The chmod +x command changes the permissions of a file to make it executable. The chmod command stands for change mode, and the +x option adds the execute permission for all users.
+Then
 
-Then simply run `./setupROOTEGPythia6.sh`
+run 
+```bash
+./setupROOTEGPythia6.sh
+```
+in your terminal. The chmod +x command changes the permissions of a file to make it executable. The chmod command stands for change mode, and the +x option adds the execute permission for all users.
 
-It clones the repo in `${HOME}` directory, and build it in  `ROOTEGPythia6_DIR/build`
-It then setup the environmental variable `ROOTEGPythia6_ROOT` in your `.zshrc` (or `.bashrc`) file. 
+## Details of the script
+
+The script clones this repository [`ROOTEGPythia6`](https://github.com/luketpickering/ROOTEGPythia6.git) 
+
+🎁 many thanks to [Luke Pickering](https://www.dunescience.org/facesofdune/luke-pickering/)
+
+For more details please visit [`ROOTEGPythia6`](https://github.com/luketpickering/ROOTEGPythia6.git).
+
+By default, it clones and build the repo in `${HOME}` directory, however one can also provide an absolute path where the repo should be cloned and build
+
+💡 **For convenience, it is suggested to clone and build this repo outside `nuwro/` directory as deleting the `nuwro/` won't affect the `ROOTEGPYthia6`**
+
+The build material is in `/path/to/ROOTEGPythia6/build` directory
+
+It then setup the environmental variable `ROOTEGPythia6_ROOT` in your `.zshrc` (or `.bashrc`) file (depending on your shell ...)
 
 Once the script ran successfully. Now proceed with installation of nuwro 
 
-The commands to install nuwro is same as before
+
+📝: Please note that the commands to install nuwro is same as before
 
 ```bash 
 make install 
 ```
+
+If you face any issues with this script, please contact the following :
+
+**Hemant Prasad**, [Email](hemant.prasad.pl@gmail.com) 📬, Faculty of Physics and Astronomy, Plac Maxa Borna 9, University of Wrocław, Poland
+

--- a/README_ROOTEGPythia6.md
+++ b/README_ROOTEGPythia6.md
@@ -1,0 +1,23 @@
+It is assumed that you have already installed ROOT v30 or higher 
+If not please visit [cern root](https://root.cern/install/build_from_source/) for building root from source 
+
+To setup ROOTEGPythia6 run `./setupROOTEGPythia6.sh`. In order to do so first make `setupROOTEGPythia6.sh` an executable file. 
+
+```bash
+chmod +x setupROOTEGPythia6.sh
+```
+
+The chmod +x command changes the permissions of a file to make it executable. The chmod command stands for change mode, and the +x option adds the execute permission for all users.
+
+Then simply run `./setupROOTEGPythia6.sh`
+
+It clones the repo in `${HOME}` directory, and build it in  `ROOTEGPythia6_DIR/build`
+It then setup the environmental variable `ROOTEGPythia6_ROOT` in your `.zshrc` (or `.bashrc`) file. 
+
+Once the script ran successfully. Now proceed with installation of nuwro 
+
+The commands to install nuwro is same as before
+
+```bash 
+make install 
+```

--- a/setupROOTEGPythia6.sh
+++ b/setupROOTEGPythia6.sh
@@ -5,36 +5,36 @@ OS=$(uname -s)
 ZSHRC_FILE="$HOME/.zshrc"
 
 if [ "$OS" == "Darwin" ]; then
-  echo "Operating System Detected: macOS"
+  echo "-> Operating System Detected: macOS ..."
   ZSHRC_FILE="${HOME}/.zshrc" # In macOS default shell is zsh hence zshrc
   # Get macOS version
   MACOS_VERSION=$(sw_vers -productVersion)
-  echo "macOS Version: $MACOS_VERSION"
+  echo "-> macOS Version: ${MACOS_VERSION} ..."
 fi
 
 if [ "$OS" == "Linux" ]; then
-  echo "Operating System Detected: Linux"
+  echo "-> Operating System Detected: Linux ..."
   if [[ "$SHELL" == *"bash"* ]]; then
     ZSHRC_FILE="${HOME}/.bashrc" # In Linux default shell is
   elif [[ "$SHELL" == *"zsh"* ]]; then
     ZSHRC_FILE="${HOME}/.bashrc" # In Linux zsh shell is being used
   else
-    echo "Unknown shell ..."
+    echo "-> Unknown shell !!."
     exit 1
   fi
   # Get kernel version
   KERNEL_VERSION=$(uname -r)
-  echo "Kernel Version: $KERNEL_VERSION"
+  echo "-> Kernel Version: ${KERNEL_VERSION} ..."
 
   # Get distribution details from /etc/os-release
   if [ -f /etc/os-release ]; then
     . /etc/os-release
     DISTRIBUTION_NAME=$NAME
     DISTRIBUTION_VERSION=$VERSION_ID
-    echo "Distribution: $DISTRIBUTION_NAME"
-    echo "Distribution Version: $DISTRIBUTION_VERSION"
+    echo "-> Distribution: ${DISTRIBUTION_NAME} ..."
+    echo "-> Distribution Version: ${DISTRIBUTION_VERSION} ..."
   else
-    echo "Distribution details not found."
+    echo "-> Distribution details not found ..."
   fi
 fi
 
@@ -51,36 +51,36 @@ DIR_NAME="ROOTEGPythia6"
 TARGET_DIR="$HOME/$DIR_NAME"
 
 # Print the default path and ask for confirmation or a new path
-echo "Cloning ROOTEGPythia6 into ${DIR_NAME} directory"
-echo "credit: Luke Pickering, for more details please visit https://github.com/luketpickering/ROOTEGPythia6.git"
+echo "-> ROOTEGPythia6 will be cloned into ${DIR_NAME} directory ..."
+echo "->* credit: Luke Pickering, for more details please visit https://github.com/luketpickering/ROOTEGPythia6.git ..."
 sleep 2
-echo "${DIR_NAME} will be created in ${HOME}/ directory."
-read -p "Do you want to proceed with the default path (y) or provide a new path? [y/n]: " choice
+echo "-> ${DIR_NAME} will be created in ${HOME}/ directory."
+read -p "-> Do you want to proceed with the default path (y) or provide a new path? [y/n]: " choice
 
 if [[ "$choice" =~ ^[Nn]$ ]]; then
   # Prompt the user for a new path
-  read -p "Please enter the new absolute path for ${DIR_NAME}: " new_path
+  read -p "-> Please enter the new absolute path for ${DIR_NAME}: " new_path
 
   # Check if the entered path is valid
   if [ -d "$new_path" ]; then
     TARGET_DIR="${new_path}/${DIR_NAME}"
-    echo "The new path for ${DIR_NAME} will be: ${TARGET_DIR}"
+    echo "-> The new path for ${DIR_NAME} will be: ${TARGET_DIR} ..."
   else
-    echo "Error: The provided path '${new_path}' is not a valid directory."
+    echo "-> Error: The provided path '${new_path}' is not a valid directory ..."
     exit 1
   fi
 else
-  echo "Proceeding with the default path: ${TARGET_DIR}"
+  echo "-> Proceeding with the default path: ${TARGET_DIR} ..."
 fi
 
 # Check if the directory already exists
 if [ -d "$TARGET_DIR" ]; then
-  echo "Directory $TARGET_DIR already exists... Entering $TARGET_DIR ..."
+  echo "-> Directory $TARGET_DIR already exists... Entering $TARGET_DIR ..."
   sleep 2
   cd "$TARGET_DIR" || exit 1 # '|| exit 1' exits the script if the cd command fails
 else
   # Create the directory
-  echo "Creating directory $TARGET_DIR..."
+  echo "-> Creating directory $TARGET_DIR..."
   mkdir -p "$TARGET_DIR"
 
   # Clone the repository into the new directory
@@ -88,54 +88,55 @@ else
 
   # Check if the clone was successful
   if [ $? -eq 0 ]; then
-    echo "Repository cloned successfully. Entering $TARGET_DIR ..."
+    echo "-> Repository cloned successfully. Entering $TARGET_DIR ..."
     cd "$TARGET_DIR" || exit 1 # '|| exit 1' exits the script if the cd command fails
   else
-    echo "Error: Failed to clone the repository."
+    echo "** Error: Failed to clone the repository ..."
     exit 1
   fi
 fi
 
 # Check if the directory already exists
 if [ -d "build" ]; then
-  echo "build/ directory already exists. Emptying build/ directory..."
+  echo "-> build/ directory already exists. Emptying build/ directory..."
   rm -r build
   mkdir -p build && cd build || exit 1 # '&&' ensures the second command only runs if the first succeeds
 else
   # Make the 'build' directory and jump into it
-  echo "Making and entering 'build/' directory..."
+  echo "-> Making and entering 'build/' directory..."
   mkdir -p build && cd build || exit 1 # '&&' ensures the second command only runs if the first succeeds
 fi
 
 # Run CMake and make install
-echo "Running CMake and make install..."
+echo "-> Running CMake and make install..."
 cmake .. -DROOTEGPythia6_Pythia6_BUILTIN=ON && make install -j 4
 
 # Check if the commands were successful
 if [ $? -eq 0 ]; then
-  echo "Build and installation completed successfully."
+  echo "-> Build and installation completed successfully ..."
 else
-  echo "Error: Build or installation failed."
+  echo "** Error: Build or installation failed ..."
   exit 1
 fi
+
+echo "-> ROOTEGPythia6 installed successfully ..."
 
 # Define the variable name and its value
 ENVM_VAR_NAME="ROOTEGPythia6_ROOT"
 ENVM_VAR_VALUE="${TARGET_DIR}/build/${OS}"
 
-echo "Setting up the environment variable $ENVM_VAR_NAME with value: $ENVM_VAR_VALUE in ${ZSHRC_FILE} file ... "
+echo "-> Checking whether environment variable ${ENVM_VAR_NAME} exists ..."
 sleep 1
 
 # Check if the variable is already in .zshrc
 if ! grep -q "export $ENVM_VAR_NAME=" "$ZSHRC_FILE"; then
   # Append the export command to the .zshrc file
-  echo "export $ENVM_VAR_NAME=\"$ENVM_VAR_VALUE\"" >>"$ZSHRC_FILE"
-  echo "Added $ENVM_VAR_NAME to $ZSHRC_FILE"
+  echo "export ${ENVM_VAR_NAME}=\"${ENVM_VAR_VALUE}\"" >>"${ZSHRC_FILE}"
+  echo "-> Added ${ENVM_VAR_NAME} to ${ZSHRC_FILE} ..."
 else
-  echo "Environment variable $ENVM_VAR_NAME already exists in $ZSHRC_FILE"
+  echo "** Environment variable ${ENVM_VAR_NAME} already exists in ${ZSHRC_FILE} ..."
 fi
 
-echo "ROOTEGPythia6 installed successfully"
 sleep 1
-echo "Please source your ${ZSHRC_FILE} file to load changes"
-echo "After that you can now prceed with NuWro installation."
+echo "-> Please source your ${ZSHRC_FILE} file to load changes ..."
+echo "-> After that you can now prceed with NuWro installation."

--- a/setupROOTEGPythia6.sh
+++ b/setupROOTEGPythia6.sh
@@ -1,0 +1,141 @@
+#!/bin/bash
+
+OS=$(uname -s)
+# Define the .zshrc (.bashrc) file path
+ZSHRC_FILE="$HOME/.zshrc"
+
+if [ "$OS" == "Darwin" ]; then
+  echo "Operating System Detected: macOS"
+  ZSHRC_FILE="${HOME}/.zshrc" # In macOS default shell is zsh hence zshrc
+  # Get macOS version
+  MACOS_VERSION=$(sw_vers -productVersion)
+  echo "macOS Version: $MACOS_VERSION"
+fi
+
+if [ "$OS" == "Linux" ]; then
+  echo "Operating System Detected: Linux"
+  if [[ "$SHELL" == *"bash"* ]]; then
+    ZSHRC_FILE="${HOME}/.bashrc" # In Linux default shell is
+  elif [[ "$SHELL" == *"zsh"* ]]; then
+    ZSHRC_FILE="${HOME}/.bashrc" # In Linux zsh shell is being used
+  else
+    echo "Unknown shell ..."
+    exit 1
+  fi
+  # Get kernel version
+  KERNEL_VERSION=$(uname -r)
+  echo "Kernel Version: $KERNEL_VERSION"
+
+  # Get distribution details from /etc/os-release
+  if [ -f /etc/os-release ]; then
+    . /etc/os-release
+    DISTRIBUTION_NAME=$NAME
+    DISTRIBUTION_VERSION=$VERSION_ID
+    echo "Distribution: $DISTRIBUTION_NAME"
+    echo "Distribution Version: $DISTRIBUTION_VERSION"
+  else
+    echo "Distribution details not found."
+  fi
+fi
+
+#sleep for 2 seconds
+sleep 1
+
+# Define the repository URL
+REPO_URL="https://github.com/luketpickering/ROOTEGPythia6.git"
+
+# Define the target directory name
+DIR_NAME="ROOTEGPythia6"
+
+# Define the full path for the target directory
+TARGET_DIR="$HOME/$DIR_NAME"
+
+# Print the default path and ask for confirmation or a new path
+echo "Cloning ROOTEGPythia6 into ${DIR_NAME} directory"
+echo "credit: Luke Pickering, for more details please visit https://github.com/luketpickering/ROOTEGPythia6.git"
+sleep 2
+echo "${DIR_NAME} will be created in ${HOME}/ directory."
+read -p "Do you want to proceed with the default path (y) or provide a new path? [y/n]: " choice
+
+if [[ "$choice" =~ ^[Nn]$ ]]; then
+  # Prompt the user for a new path
+  read -p "Please enter the new absolute path for ${DIR_NAME}: " new_path
+
+  # Check if the entered path is valid
+  if [ -d "$new_path" ]; then
+    TARGET_DIR="${new_path}/${DIR_NAME}"
+    echo "The new path for ${DIR_NAME} will be: ${TARGET_DIR}"
+  else
+    echo "Error: The provided path '${new_path}' is not a valid directory."
+    exit 1
+  fi
+else
+  echo "Proceeding with the default path: ${TARGET_DIR}"
+fi
+
+# Check if the directory already exists
+if [ -d "$TARGET_DIR" ]; then
+  echo "Directory $TARGET_DIR already exists... Entering $TARGET_DIR ..."
+  sleep 2
+  cd "$TARGET_DIR" || exit 1 # '|| exit 1' exits the script if the cd command fails
+else
+  # Create the directory
+  echo "Creating directory $TARGET_DIR..."
+  mkdir -p "$TARGET_DIR"
+
+  # Clone the repository into the new directory
+  git clone "$REPO_URL" "$TARGET_DIR"
+
+  # Check if the clone was successful
+  if [ $? -eq 0 ]; then
+    echo "Repository cloned successfully. Entering $TARGET_DIR ..."
+    cd "$TARGET_DIR" || exit 1 # '|| exit 1' exits the script if the cd command fails
+  else
+    echo "Error: Failed to clone the repository."
+    exit 1
+  fi
+fi
+
+# Check if the directory already exists
+if [ -d "build" ]; then
+  echo "build/ directory already exists. Emptying build/ directory..."
+  rm -r build
+  mkdir -p build && cd build || exit 1 # '&&' ensures the second command only runs if the first succeeds
+else
+  # Make the 'build' directory and jump into it
+  echo "Making and entering 'build/' directory..."
+  mkdir -p build && cd build || exit 1 # '&&' ensures the second command only runs if the first succeeds
+fi
+
+# Run CMake and make install
+echo "Running CMake and make install..."
+cmake .. -DROOTEGPythia6_Pythia6_BUILTIN=ON && make install -j 4
+
+# Check if the commands were successful
+if [ $? -eq 0 ]; then
+  echo "Build and installation completed successfully."
+else
+  echo "Error: Build or installation failed."
+  exit 1
+fi
+
+# Define the variable name and its value
+ENVM_VAR_NAME="ROOTEGPythia6_ROOT"
+ENVM_VAR_VALUE="${TARGET_DIR}/build/${OS}"
+
+echo "Setting up the environment variable $ENVM_VAR_NAME with value: $ENVM_VAR_VALUE in ${ZSHRC_FILE} file ... "
+sleep 1
+
+# Check if the variable is already in .zshrc
+if ! grep -q "export $ENVM_VAR_NAME=" "$ZSHRC_FILE"; then
+  # Append the export command to the .zshrc file
+  echo "export $ENVM_VAR_NAME=\"$ENVM_VAR_VALUE\"" >>"$ZSHRC_FILE"
+  echo "Added $ENVM_VAR_NAME to $ZSHRC_FILE"
+else
+  echo "Environment variable $ENVM_VAR_NAME already exists in $ZSHRC_FILE"
+fi
+
+echo "ROOTEGPythia6 installed successfully"
+sleep 1
+echo "Please source your ${ZSHRC_FILE} file to load changes"
+echo "After that you can now prceed with NuWro installation."

--- a/src/params.xml
+++ b/src/params.xml
@@ -344,8 +344,12 @@
       <option key="1"><![CDATA[local Fermi momentum]]></option>
       <option key="2"><![CDATA[TG approach - use MC method to decide about PB, according to a nucleon momentum distribution given by spectral function]]></option>
     </options>
-  </param>  <param name="cc_smoothing" type="checkbox" ctype="bool" default="1">
+  </param>  <param name="cc_smoothing" type="checkbox" ctype="bool" default="0">
     <description><![CDATA[A little performace gain in the QEL channel can be obtained by using: cc_smoothing=1]]></description>
+    <options>
+      <option key="0"><![CDATA[No CC cc_smoothing]]></option>
+      <option key="1"><![CDATA[Little performance gain in QEL channel. Do not try impossible QEL reaction like nu+N]]></option>
+    </options>
   </param>
   <param name="delta_FF_set" type="select" ctype="int" default="1">
     <description><![CDATA[Dipole delta form factors]]></description>

--- a/src/params.xml
+++ b/src/params.xml
@@ -427,13 +427,14 @@
   <param name="coh_kind" type="checkbox" ctype="int" default="2">
     <description><![CDATA[Switch between Rein-Sehgal (1) and Berger Sehgal(2) models]]></description>
   </param>
-  <param name="mec_kind" type="select" ctype="int" default="3">
+  <param name="mec_kind" type="select" ctype="int" default="6">
     <description><![CDATA[MEC model]]></description>
     <options>
       <option key="1"><![CDATA[TEM model]]></option>
       <option key="2"><![CDATA[Marteau model]]></option>
       <option key="3"><![CDATA[Nieves model]]></option>
       <option key="5"><![CDATA[SuSAv2 model]]></option>
+      <option key="6"><![CDATA[Valencia 2020 Model]]></option>
     </options>
   </param>
   <param name="mec_ratio_pp" type="text" ctype="double" default="0.85">

--- a/src/params_all.h
+++ b/src/params_all.h
@@ -78,7 +78,7 @@ PARAM(int,sf_method,0)\
 PARAM(bool,sf_fsi,1)\
 PARAM(bool,sf_coulomb,1)\
 PARAM(int,sf_pb,1)\
-PARAM(bool,cc_smoothing,1)\
+PARAM(bool,cc_smoothing,0)\
 PARAM(int,delta_FF_set,1)\
 PARAM(int,e_spp_ff_set,4)\
 PARAM(int,delta_selfenergy,0)\
@@ -94,7 +94,7 @@ PARAM(int,res_hybrid_resampling,0)\
 PARAM(bool,coh_mass_correction,1)\
 PARAM(bool,coh_new,1)\
 PARAM(int,coh_kind,2)\
-PARAM(int,mec_kind,3)\
+PARAM(int,mec_kind,6)\
 PARAM(double,mec_ratio_pp,0.85)\
 PARAM(double,mec_ratio_ppp,0.8)\
 PARAM(double,mec_central_motion,0.0)\


### PR DESCRIPTION
This updates contains NuWro version (which still uses Pythia6) compatible with new ROOT version (`v30` or higher), which can also run on new macOS versions (`v15` or higher).

There is new script file `setupROOTEGPythia6.sh`.  A new `README_ROOTEGPythia6.md` is provided for the details of the script.

Line no. `18`, `21` and `25` are changed in Makefile which loads  `ROOTEGPythia6` libraries for `Pythia6` header files.